### PR TITLE
fix(deploy): uv をフルパス指定に変更 (/usr/local/bin/uv)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Install dependencies
         working-directory: /Awaji-Empire-Agent/discord_bot
         run: |
-          # /usr/local/bin にある uv をそのまま使用
-          uv sync
+          /usr/local/bin/uv sync
 
       - name: Restart Services
         run: |
@@ -58,8 +57,7 @@ jobs:
       - name: Install dependencies
         working-directory: /Awaji-Empire-Agent/discord_bot
         run: |
-          # /usr/local/bin にある uv をそのまま使用
-          uv sync
+          /usr/local/bin/uv sync
 
       - name: Restart Services
         run: |


### PR DESCRIPTION
ランナー環境では PATH が限定されるため uv が見つからず exit 127 になっていた