### PR TITLE
fix(deploy): uv 未インストール時の自動セットアップステップを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,12 @@ jobs:
         run: |
           sudo rsync -av --exclude='.git' ./ /Awaji-Empire-Agent/
 
+      - name: Install uv
+        run: |
+          if ! command -v /usr/local/bin/uv &> /dev/null; then
+            curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR=/usr/local/bin sh
+          fi
+
       - name: Install dependencies
         working-directory: /Awaji-Empire-Agent/discord_bot
         run: |
@@ -53,6 +59,12 @@ jobs:
       - name: Sync to production directory
         run: |
           sudo rsync -av --exclude='.git' ./ /Awaji-Empire-Agent/
+
+      - name: Install uv
+        run: |
+          if ! command -v /usr/local/bin/uv &> /dev/null; then
+            curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR=/usr/local/bin sh
+          fi
 
       - name: Install dependencies
         working-directory: /Awaji-Empire-Agent/discord_bot


### PR DESCRIPTION
- Install uv ステップを本番テスト両ジョブに追加
- uv が /usr/local/bin にない場合のみ curl でインストール（冪等）
- UV_INSTALL_DIR=/usr/local/bin でランナー環境からも参照可能