### PR TITLE
fix(rust-bridge): sqlxビルドエラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,11 @@ jobs:
       - name: Build Rust bridge
         working-directory: ./database_bridge
         run: |
-          # Rust の環境変数を読み込んでビルド
           source "$HOME/.cargo/env"
+          # discord_bot/.env から DATABASE_URL を読み込む（sqlx::query! マクロ用）
+          if [ -f /Awaji-Empire-Agent/discord_bot/.env ]; then
+            set -a && source /Awaji-Empire-Agent/discord_bot/.env && set +a
+          fi
           cargo build --release
 
       - name: Sync to production directory
@@ -56,8 +59,11 @@ jobs:
       - name: Build Rust bridge
         working-directory: ./database_bridge
         run: |
-          # Rust の環境変数を読み込んでビルド
           source "$HOME/.cargo/env"
+          # discord_bot/.env から DATABASE_URL を読み込む（sqlx::query! マクロ用）
+          if [ -f /Awaji-Empire-Agent/discord_bot/.env ]; then
+            set -a && source /Awaji-Empire-Agent/discord_bot/.env && set +a
+          fi
           cargo build --release
 
       - name: Sync to production directory

--- a/database_bridge/src/api/handlers.rs
+++ b/database_bridge/src/api/handlers.rs
@@ -4,10 +4,10 @@
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{json, Value};
 use sqlx::MySqlPool;
-use tracing::{error, info};
+use tracing::error;
 
 use crate::db::{models::BridgeError, survey_repo, response_repo, log_repo};
 use crate::bot::survey_handler;

--- a/database_bridge/src/bot/survey_handler.rs
+++ b/database_bridge/src/bot/survey_handler.rs
@@ -5,7 +5,7 @@
 
 use sqlx::mysql::MySqlPool;
 
-use crate::db::{models::BridgeResult, models::BridgeError, response_repo, survey_repo};
+use crate::db::{models::BridgeResult, models::BridgeError, survey_repo};
 
 /// アンケート回答を UPSERT する（UNIQUE KEY: survey_id + user_id を前提）。
 ///

--- a/database_bridge/src/db/models.rs
+++ b/database_bridge/src/db/models.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
-use time::OffsetDateTime;
+use sqlx::types::time::OffsetDateTime;
 
 // ============================================================
 // surveys テーブル


### PR DESCRIPTION
- db/models.rs: use time::OffsetDateTime を sqlx::types::time::OffsetDateTime に変更 time クレートの直接依存なしで sqlx feature 経由の型を使用するよう修正 (E0432解消)
- api/handlers.rs: 未使用 import Serialize, info を削除 (warning除去)
- bot/survey_handler.rs: 未使用 import 
esponse_repo を削除 (warning除去)
- .github/workflows/deploy.yml: Rustビルド時に /Awaji-Empire-Agent/discord_bot/.env から DATABASE_URL を読み込む処理を追加 (sqlx::query! マクロのコンパイル時DB検証を有効化)