### PR TITLE
fix(rust-bridge): OffsetDateTimeのserde実装を修正・未使用importを削除

### DIFF
--- a/database_bridge/Cargo.toml
+++ b/database_bridge/Cargo.toml
@@ -16,6 +16,9 @@ sqlx = { version = "0.8", features = [
     "time",     # OffsetDateTime サポート
 ] }
 
+# OffsetDateTime の serde 実装（sqlx の time feature だけでは serde が有効にならない）
+time = { version = "0.3", features = ["serde"] }
+
 # JSON シリアライズ・デシリアライズ
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/database_bridge/src/api/mod.rs
+++ b/database_bridge/src/api/mod.rs
@@ -4,7 +4,7 @@
 pub mod handlers;
 
 use axum::{
-    routing::{get, post, patch, delete},
+    routing::{get, post, patch},
     Router,
 };
 use sqlx::MySqlPool;


### PR DESCRIPTION
- Cargo.toml: time = { version=0.3, features=[serde] } を直接依存に追加 sqlx の time feature だけでは OffsetDateTime の Serialize/Deserialize が 有効にならないため time crate を明示的に依存させる (E0277解消)
- api/mod.rs: routing::delete を削除 (unused warning) .delete() はMethodRouterのメソッドであり routing::delete とは別物