### PR TITLE
refactor(rust-bridge): sqlx::query!マクロをランタイムAPIに全面移行

### DIFF
--- a/database_bridge/Cargo.toml
+++ b/database_bridge/Cargo.toml
@@ -11,8 +11,7 @@ tokio = { version = "1", features = ["full"] }
 sqlx = { version = "0.8", features = [
     "runtime-tokio",
     "tls-rustls",
-    "mysql",    # MariaDB/MySQL 対応 (postgres から変更)
-    "macros",
+    "mysql",    # MariaDB/MySQL 対応
     "time",     # OffsetDateTime サポート
 ] }
 

--- a/database_bridge/src/bot/survey_handler.rs
+++ b/database_bridge/src/bot/survey_handler.rs
@@ -2,6 +2,8 @@
 // Why: Discord Bot 固有のロジック（UPSERT・ owner 照合付きステータス切替）を格納する。
 //      これらの処理は「Bot のコンテキストでのみ意味を持つ複合操作」であり、
 //      純粋な CRUD とは分けることで db/ の単一責任を維持する。
+//
+//      Note: sqlx::query!マクロの代わりに sqlx::query() ランタイム関数を使用。
 
 use sqlx::mysql::MySqlPool;
 
@@ -24,7 +26,7 @@ pub async fn upsert_response(
 
     // ON DUPLICATE KEY UPDATE: UNIQUE KEY (survey_id, user_id) が設定されている前提。
     // last_insert_id() は INSERT 時は新規 ID、UPDATE 時は既存 ID を返す（MariaDB 仕様）。
-    let result = sqlx::query!(
+    let result = sqlx::query(
         r#"
         INSERT INTO survey_responses
             (survey_id, user_id, user_name, answers, submitted_at, dm_sent)
@@ -34,11 +36,11 @@ pub async fn upsert_response(
             submitted_at = NOW(),
             dm_sent     = FALSE
         "#,
-        survey_id,
-        user_id,
-        user_name,
-        answers_json,
     )
+    .bind(survey_id)
+    .bind(user_id)
+    .bind(user_name)
+    .bind(answers_json)
     .execute(pool)
     .await
     .map_err(BridgeError::Sqlx)?;
@@ -62,14 +64,12 @@ pub async fn toggle_status(
 
     let new_status = !survey.is_active;
 
-    sqlx::query!(
-        "UPDATE surveys SET is_active = ? WHERE id = ?",
-        new_status,
-        survey_id,
-    )
-    .execute(pool)
-    .await
-    .map_err(BridgeError::Sqlx)?;
+    sqlx::query("UPDATE surveys SET is_active = ? WHERE id = ?")
+        .bind(new_status)
+        .bind(survey_id)
+        .execute(pool)
+        .await
+        .map_err(BridgeError::Sqlx)?;
 
     Ok(new_status)
 }

--- a/database_bridge/src/db/log_repo.rs
+++ b/database_bridge/src/db/log_repo.rs
@@ -1,10 +1,12 @@
 // db/log_repo.rs
 // Why: operation_logs テーブルへの INSERT をここに集約する。
 //      Python の `LogService.log_operation()` に相当。
+//
+//      Note: sqlx::query!マクロの代わりに sqlx::query() ランタイム関数を使用。
 
 use sqlx::mysql::MySqlPool;
 
-use super::models::{BridgeResult};
+use super::models::{BridgeResult, OperationLog};
 
 /// 操作ログを operation_logs テーブルに INSERT する。
 ///
@@ -16,13 +18,13 @@ pub async fn insert(
     command: &str,
     detail: &str,
 ) -> BridgeResult<()> {
-    sqlx::query!(
+    sqlx::query(
         "INSERT INTO operation_logs (user_id, user_name, command, detail) VALUES (?, ?, ?, ?)",
-        user_id,
-        user_name,
-        command,
-        detail,
     )
+    .bind(user_id)
+    .bind(user_name)
+    .bind(command)
+    .bind(detail)
     .execute(pool)
     .await?;
 
@@ -32,12 +34,11 @@ pub async fn insert(
 /// 最新の operation_logs を件数指定で取得する。
 ///
 /// Why: webapp/dashboard_query.rs から呼ばれる集計クエリ。
-pub async fn find_recent(pool: &MySqlPool, limit: u32) -> BridgeResult<Vec<super::models::OperationLog>> {
-    let logs = sqlx::query_as!(
-        super::models::OperationLog,
+pub async fn find_recent(pool: &MySqlPool, limit: u32) -> BridgeResult<Vec<OperationLog>> {
+    let logs = sqlx::query_as::<_, OperationLog>(
         "SELECT * FROM operation_logs ORDER BY created_at DESC LIMIT ?",
-        limit,
     )
+    .bind(limit)
     .fetch_all(pool)
     .await?;
 

--- a/database_bridge/src/db/response_repo.rs
+++ b/database_bridge/src/db/response_repo.rs
@@ -1,8 +1,10 @@
 // db/response_repo.rs
 // Why: survey_responses テーブルへの純粋な CRUD をここに集約する。
 //      UPSERT ロジック（Bot 固有）は bot/survey_handler.rs に分離している。
+//
+//      Note: sqlx::query!マクロの代わりに sqlx::query() ランタイム関数を使用。
 
-use sqlx::mysql::MySqlPool;
+use sqlx::{mysql::MySqlPool, Row};
 
 use super::models::{BridgeError, BridgeResult, SurveyResponse};
 
@@ -10,11 +12,10 @@ use super::models::{BridgeError, BridgeResult, SurveyResponse};
 ///
 /// Python: `SurveyService.get_responses()`
 pub async fn find_by_survey(pool: &MySqlPool, survey_id: i64) -> BridgeResult<Vec<SurveyResponse>> {
-    let responses = sqlx::query_as!(
-        SurveyResponse,
+    let responses = sqlx::query_as::<_, SurveyResponse>(
         "SELECT * FROM survey_responses WHERE survey_id = ? ORDER BY submitted_at DESC",
-        survey_id,
     )
+    .bind(survey_id)
     .fetch_all(pool)
     .await?;
 
@@ -30,27 +31,25 @@ pub async fn find_answers_by_user(
     survey_id: i64,
     user_id: &str,
 ) -> BridgeResult<Option<String>> {
-    let row = sqlx::query!(
+    let row = sqlx::query(
         "SELECT answers FROM survey_responses WHERE survey_id = ? AND user_id = ?",
-        survey_id,
-        user_id,
     )
+    .bind(survey_id)
+    .bind(user_id)
     .fetch_optional(pool)
     .await?;
 
-    Ok(row.map(|r| r.answers))
+    Ok(row.map(|r| r.try_get::<String, _>("answers").unwrap_or_default()))
 }
 
 /// 回答レコードの DM 送信済みフラグを立てる。
 ///
 /// Python: `SurveyService.mark_dm_sent()`
 pub async fn mark_dm_sent(pool: &MySqlPool, response_id: i64) -> BridgeResult<()> {
-    sqlx::query!(
-        "UPDATE survey_responses SET dm_sent = TRUE WHERE id = ?",
-        response_id,
-    )
-    .execute(pool)
-    .await?;
+    sqlx::query("UPDATE survey_responses SET dm_sent = TRUE WHERE id = ?")
+        .bind(response_id)
+        .execute(pool)
+        .await?;
 
     Ok(())
 }
@@ -61,11 +60,11 @@ pub(crate) async fn update_response(
     response_id: i64,
     answers_json: &str,
 ) -> BridgeResult<()> {
-    sqlx::query!(
+    sqlx::query(
         "UPDATE survey_responses SET answers = ?, submitted_at = NOW(), dm_sent = FALSE WHERE id = ?",
-        answers_json,
-        response_id,
     )
+    .bind(answers_json)
+    .bind(response_id)
     .execute(pool)
     .await?;
 
@@ -80,17 +79,15 @@ pub(crate) async fn insert_response(
     user_name: &str,
     answers_json: &str,
 ) -> BridgeResult<i64> {
-    let result = sqlx::query!(
-        r#"
-        INSERT INTO survey_responses
-            (survey_id, user_id, user_name, answers, submitted_at, dm_sent)
-        VALUES (?, ?, ?, ?, NOW(), FALSE)
-        "#,
-        survey_id,
-        user_id,
-        user_name,
-        answers_json,
+    let result = sqlx::query(
+        "INSERT INTO survey_responses \
+             (survey_id, user_id, user_name, answers, submitted_at, dm_sent) \
+         VALUES (?, ?, ?, ?, NOW(), FALSE)",
     )
+    .bind(survey_id)
+    .bind(user_id)
+    .bind(user_name)
+    .bind(answers_json)
     .execute(pool)
     .await
     .map_err(BridgeError::Sqlx)?;

--- a/database_bridge/src/db/survey_repo.rs
+++ b/database_bridge/src/db/survey_repo.rs
@@ -2,8 +2,11 @@
 // Why: surveys テーブルへの純粋な CRUD をここに集約する。
 //      本ファイルは Bot / Webapp 両方から呼ばれるため、
 //      Discord にも Quart にも依存しない純粋な Rust コードのみを記述する。
+//
+//      Note: sqlx::query!マクロ（コンパイル時DB検証）の代わりに
+//      sqlx::query()ランタイム関数を使用。CI環境のDATABASE_URL依存を排除する。
 
-use sqlx::mysql::MySqlPool;
+use sqlx::{mysql::MySqlPool, Row};
 use tracing::error;
 
 use super::models::{BridgeError, BridgeResult, Survey};
@@ -12,13 +15,11 @@ use super::models::{BridgeError, BridgeResult, Survey};
 ///
 /// Python: `SurveyService.create_survey()`
 pub async fn insert(pool: &MySqlPool, owner_id: &str) -> BridgeResult<i64> {
-    let result = sqlx::query!(
-        r#"
-        INSERT INTO surveys (owner_id, title, questions, is_active, created_at)
-        VALUES (?, '無題のアンケート', '[]', FALSE, NOW())
-        "#,
-        owner_id,
+    let result = sqlx::query(
+        "INSERT INTO surveys (owner_id, title, questions, is_active, created_at) \
+         VALUES (?, '無題のアンケート', '[]', FALSE, NOW())",
     )
+    .bind(owner_id)
     .execute(pool)
     .await
     .map_err(|e| {
@@ -33,7 +34,8 @@ pub async fn insert(pool: &MySqlPool, owner_id: &str) -> BridgeResult<i64> {
 ///
 /// Python: `SurveyService.get_survey()`
 pub async fn find_by_id(pool: &MySqlPool, survey_id: i64) -> BridgeResult<Survey> {
-    sqlx::query_as!(Survey, "SELECT * FROM surveys WHERE id = ?", survey_id)
+    sqlx::query_as::<_, Survey>("SELECT * FROM surveys WHERE id = ?")
+        .bind(survey_id)
         .fetch_optional(pool)
         .await?
         .ok_or_else(|| BridgeError::NotFound(format!("survey_id={survey_id}")))
@@ -49,19 +51,17 @@ pub async fn find_by_owner(
     active_only: Option<bool>,
 ) -> BridgeResult<Vec<Survey>> {
     let surveys = if active_only == Some(true) {
-        sqlx::query_as!(
-            Survey,
+        sqlx::query_as::<_, Survey>(
             "SELECT * FROM surveys WHERE owner_id = ? AND is_active = 1 ORDER BY created_at DESC",
-            owner_id,
         )
+        .bind(owner_id)
         .fetch_all(pool)
         .await?
     } else {
-        sqlx::query_as!(
-            Survey,
+        sqlx::query_as::<_, Survey>(
             "SELECT * FROM surveys WHERE owner_id = ? ORDER BY created_at DESC",
-            owner_id,
         )
+        .bind(owner_id)
         .fetch_all(pool)
         .await?
     };
@@ -73,8 +73,7 @@ pub async fn find_by_owner(
 ///
 /// Python: `SurveyService.get_active_surveys()`
 pub async fn find_active(pool: &MySqlPool) -> BridgeResult<Vec<Survey>> {
-    let surveys = sqlx::query_as!(
-        Survey,
+    let surveys = sqlx::query_as::<_, Survey>(
         "SELECT * FROM surveys WHERE is_active = 1 ORDER BY created_at DESC",
     )
     .fetch_all(pool)
@@ -92,14 +91,12 @@ pub async fn update(
     title: &str,
     questions_json: &str,
 ) -> BridgeResult<()> {
-    sqlx::query!(
-        "UPDATE surveys SET title = ?, questions = ? WHERE id = ?",
-        title,
-        questions_json,
-        survey_id,
-    )
-    .execute(pool)
-    .await?;
+    sqlx::query("UPDATE surveys SET title = ?, questions = ? WHERE id = ?")
+        .bind(title)
+        .bind(questions_json)
+        .bind(survey_id)
+        .execute(pool)
+        .await?;
 
     Ok(())
 }
@@ -114,7 +111,8 @@ pub async fn delete(pool: &MySqlPool, survey_id: i64, owner_id: &str) -> BridgeR
         return Err(BridgeError::PermissionDenied);
     }
 
-    sqlx::query!("DELETE FROM surveys WHERE id = ?", survey_id)
+    sqlx::query("DELETE FROM surveys WHERE id = ?")
+        .bind(survey_id)
         .execute(pool)
         .await?;
 
@@ -125,10 +123,11 @@ pub async fn delete(pool: &MySqlPool, survey_id: i64, owner_id: &str) -> BridgeR
 ///
 /// Python: `SurveyService.get_owner_id()`
 pub async fn get_owner_id(pool: &MySqlPool, survey_id: i64) -> BridgeResult<String> {
-    let row = sqlx::query!("SELECT owner_id FROM surveys WHERE id = ?", survey_id)
+    let row = sqlx::query("SELECT owner_id FROM surveys WHERE id = ?")
+        .bind(survey_id)
         .fetch_optional(pool)
         .await?
         .ok_or_else(|| BridgeError::NotFound(format!("survey_id={survey_id}")))?;
 
-    Ok(row.owner_id)
+    Ok(row.try_get("owner_id").map_err(BridgeError::Sqlx)?)
 }


### PR DESCRIPTION
DATABASE_URL のコンパイル時要件を排除し、CI環境依存を完全に解消する。

Before: sqlx::query!(SQL, args) / sqlx::query_as!(Type, SQL, args)
  → コンパイル時にDATABASE_URLとDB接続が必要
After:  sqlx::query(SQL).bind(arg) / sqlx::query_as::<_, Type>(SQL).bind(arg)
  → ランタイムに型安全なクエリ実行（コンパイル時DB不要）

変更ファイル:
- db/survey_repo.rs: 全8クエリをランタイムAPIに変換
- db/response_repo.rs: 全5クエリをランタイムAPIに変換
- db/log_repo.rs: 全2クエリをランタイムAPIに変換
- bot/survey_handler.rs: 全2クエリをランタイムAPIに変換
- Cargo.toml: macros feature を削除（不要になったため）