### PR TITLE
fix(rust-bridge): Warningを全削除・uv sync権限エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Install dependencies
         working-directory: /Awaji-Empire-Agent/discord_bot
         run: |
+          # .venv が root 所有の場合、devuser に所有権を移譲して uv sync を可能にする
+          if [ -d .venv ]; then
+            sudo chown -R "$(whoami):$(whoami)" .venv
+          fi
           /usr/local/bin/uv sync
 
       - name: Restart Services
@@ -79,6 +83,10 @@ jobs:
       - name: Install dependencies
         working-directory: /Awaji-Empire-Agent/discord_bot
         run: |
+          # .venv が root 所有の場合、devuser に所有権を移譲して uv sync を可能にする
+          if [ -d .venv ]; then
+            sudo chown -R "$(whoami):$(whoami)" .venv
+          fi
           /usr/local/bin/uv sync
 
       - name: Restart Services

--- a/database_bridge/src/db/response_repo.rs
+++ b/database_bridge/src/db/response_repo.rs
@@ -6,7 +6,7 @@
 
 use sqlx::{mysql::MySqlPool, Row};
 
-use super::models::{BridgeError, BridgeResult, SurveyResponse};
+use super::models::{BridgeResult, SurveyResponse};
 
 /// アンケートの全回答を取得する。
 ///
@@ -52,45 +52,4 @@ pub async fn mark_dm_sent(pool: &MySqlPool, response_id: i64) -> BridgeResult<()
         .await?;
 
     Ok(())
-}
-
-/// 既存回答レコードを UPDATE する（UPSERT の UPDATE 分岐。bot/ から呼ばれる）。
-pub(crate) async fn update_response(
-    pool: &MySqlPool,
-    response_id: i64,
-    answers_json: &str,
-) -> BridgeResult<()> {
-    sqlx::query(
-        "UPDATE survey_responses SET answers = ?, submitted_at = NOW(), dm_sent = FALSE WHERE id = ?",
-    )
-    .bind(answers_json)
-    .bind(response_id)
-    .execute(pool)
-    .await?;
-
-    Ok(())
-}
-
-/// 新規回答レコードを INSERT する（UPSERT の INSERT 分岐。bot/ から呼ばれる）。
-pub(crate) async fn insert_response(
-    pool: &MySqlPool,
-    survey_id: i64,
-    user_id: &str,
-    user_name: &str,
-    answers_json: &str,
-) -> BridgeResult<i64> {
-    let result = sqlx::query(
-        "INSERT INTO survey_responses \
-             (survey_id, user_id, user_name, answers, submitted_at, dm_sent) \
-         VALUES (?, ?, ?, ?, NOW(), FALSE)",
-    )
-    .bind(survey_id)
-    .bind(user_id)
-    .bind(user_name)
-    .bind(answers_json)
-    .execute(pool)
-    .await
-    .map_err(BridgeError::Sqlx)?;
-
-    Ok(result.last_insert_id() as i64)
 }

--- a/database_bridge/src/main.rs
+++ b/database_bridge/src/main.rs
@@ -2,9 +2,7 @@
 // Why: HTTP サーバーエントリエントリポイント (IPC用)。
 //      Phase 3-B では axum を使用してローカルのリクエストを受け付ける。
 
-use axum::{routing::get, Json, Router};
 use database_bridge::db::connection;
-use serde_json::{json, Value};
 use std::net::SocketAddr;
 use tracing::{error, info};
 


### PR DESCRIPTION
[Rust Warning 修正]
- response_repo.rs: 未使用の update_response / insert_response を削除
- response_repo.rs: 未使用の BridgeError import を削除
- main.rs: 未使用 import (routing::get, Json, Router, json, Value) を削除

[uv sync 権限エラー修正]
- deploy.yml: uv sync 前に sudo chown -R でdevuserに所有権移譲 (sudo rm -rf は避け、.venvを保全したまま Permission denied を解消)