### PR TITLE
fix(rust-bridge): DATETIME型のデコード失敗をCASTで回避

### DIFF
--- a/database_bridge/src/db/log_repo.rs
+++ b/database_bridge/src/db/log_repo.rs
@@ -1,16 +1,14 @@
 // db/log_repo.rs
-// Why: operation_logs テーブルへの INSERT をここに集約する。
-//      Python の `LogService.log_operation()` に相当。
-//
-//      Note: sqlx::query!マクロの代わりに sqlx::query() ランタイム関数を使用。
+// Why: operation_logs テーブルへの操作を集約する。
 
 use sqlx::mysql::MySqlPool;
 
 use super::models::{BridgeResult, OperationLog};
 
+/// SQL で DATETIME を文字列として取得するためのカラムリスト。
+const SELECT_COLUMNS: &str = "id, user_id, user_name, command, detail, CAST(created_at AS CHAR) as created_at";
+
 /// 操作ログを operation_logs テーブルに INSERT する。
-///
-/// Python: `LogService.log_operation()`
 pub async fn insert(
     pool: &MySqlPool,
     user_id: &str,
@@ -32,15 +30,12 @@ pub async fn insert(
 }
 
 /// 最新の operation_logs を件数指定で取得する。
-///
-/// Why: webapp/dashboard_query.rs から呼ばれる集計クエリ。
 pub async fn find_recent(pool: &MySqlPool, limit: u32) -> BridgeResult<Vec<OperationLog>> {
-    let logs = sqlx::query_as::<_, OperationLog>(
-        "SELECT * FROM operation_logs ORDER BY created_at DESC LIMIT ?",
-    )
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
+    let sql = format!("SELECT {} FROM operation_logs ORDER BY created_at DESC LIMIT ?", SELECT_COLUMNS);
+    let logs = sqlx::query_as::<_, OperationLog>(&sql)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
 
     Ok(logs)
 }

--- a/database_bridge/src/db/response_repo.rs
+++ b/database_bridge/src/db/response_repo.rs
@@ -1,53 +1,44 @@
 // db/response_repo.rs
-// Why: survey_responses テーブルへの純粋な CRUD をここに集約する。
-//      UPSERT ロジック（Bot 固有）は bot/survey_handler.rs に分離している。
-//
-//      Note: sqlx::query!マクロの代わりに sqlx::query() ランタイム関数を使用。
+// Why: survey_responses テーブルへの操作を集約する。
 
-use sqlx::{mysql::MySqlPool, Row};
+use sqlx::mysql::MySqlPool;
 
 use super::models::{BridgeResult, SurveyResponse};
 
-/// アンケートの全回答を取得する。
-///
-/// Python: `SurveyService.get_responses()`
+/// SQL で DATETIME を文字列として取得するためのカラムリスト。
+const SELECT_COLUMNS: &str = "id, survey_id, user_id, user_name, answers, CAST(submitted_at AS CHAR) as submitted_at, dm_sent";
+
+/// 特定のアンケートに対する全回答を取得する。
 pub async fn find_by_survey(pool: &MySqlPool, survey_id: i64) -> BridgeResult<Vec<SurveyResponse>> {
-    let responses = sqlx::query_as::<_, SurveyResponse>(
-        "SELECT * FROM survey_responses WHERE survey_id = ? ORDER BY submitted_at DESC",
-    )
-    .bind(survey_id)
-    .fetch_all(pool)
-    .await?;
+    let sql = format!("SELECT {} FROM survey_responses WHERE survey_id = ? ORDER BY submitted_at DESC", SELECT_COLUMNS);
+    let responses = sqlx::query_as::<_, SurveyResponse>(&sql)
+        .bind(survey_id)
+        .fetch_all(pool)
+        .await?;
 
     Ok(responses)
 }
 
-/// ユーザーの既存回答 JSON 文字列を取得する。
-///
-/// Python: `SurveyService.get_existing_answers()`
-/// 回答がなければ `None` を返す。
+/// 特定のユーザーがそのアンケートに回答済みか確認し、回答を返す。
 pub async fn find_answers_by_user(
     pool: &MySqlPool,
     survey_id: i64,
     user_id: &str,
-) -> BridgeResult<Option<String>> {
-    let row = sqlx::query(
-        "SELECT answers FROM survey_responses WHERE survey_id = ? AND user_id = ?",
-    )
-    .bind(survey_id)
-    .bind(user_id)
-    .fetch_optional(pool)
-    .await?;
+) -> BridgeResult<Option<SurveyResponse>> {
+    // user_id は BIGINT なのでパース
+    let user_id_int = user_id.parse::<i64>().unwrap_or(0);
+    
+    let sql = format!("SELECT {} FROM survey_responses WHERE survey_id = ? AND user_id = ?", SELECT_COLUMNS);
+    let response = sqlx::query_as::<_, SurveyResponse>(&sql)
+        .bind(survey_id)
+        .bind(user_id_int)
+        .fetch_optional(pool)
+        .await?;
 
-    Ok(row.map(|r| {
-        let bytes = r.try_get::<Vec<u8>, _>("answers").unwrap_or_default();
-        String::from_utf8_lossy(&bytes).into_owned()
-    }))
+    Ok(response)
 }
 
-/// 回答レコードの DM 送信済みフラグを立てる。
-///
-/// Python: `SurveyService.mark_dm_sent()`
+/// DM 送信済みフラグを更新する。
 pub async fn mark_dm_sent(pool: &MySqlPool, response_id: i64) -> BridgeResult<()> {
     sqlx::query("UPDATE survey_responses SET dm_sent = TRUE WHERE id = ?")
         .bind(response_id)

--- a/database_bridge/src/db/survey_repo.rs
+++ b/database_bridge/src/db/survey_repo.rs
@@ -6,6 +6,10 @@ use tracing::error;
 
 use super::models::{BridgeError, BridgeResult, Survey};
 
+/// SQL で DATETIME を文字列として取得するためのカラムリスト。
+/// Why: sqlx は DATETIME 型を直接 String にデコードできないため、DB 側で変換する。
+const SELECT_COLUMNS: &str = "id, owner_id, title, questions, is_active, CAST(created_at AS CHAR) as created_at";
+
 /// 新規アンケートを INSERT し、生成された ID を返す。
 pub async fn insert(pool: &MySqlPool, owner_id: &str) -> BridgeResult<i64> {
     let result = sqlx::query(
@@ -25,7 +29,8 @@ pub async fn insert(pool: &MySqlPool, owner_id: &str) -> BridgeResult<i64> {
 
 /// ID でアンケートを 1 件取得する。
 pub async fn find_by_id(pool: &MySqlPool, survey_id: i64) -> BridgeResult<Survey> {
-    sqlx::query_as::<_, Survey>("SELECT * FROM surveys WHERE id = ?")
+    let sql = format!("SELECT {} FROM surveys WHERE id = ?", SELECT_COLUMNS);
+    sqlx::query_as::<_, Survey>(&sql)
         .bind(survey_id)
         .fetch_optional(pool)
         .await?
@@ -38,48 +43,34 @@ pub async fn find_by_owner(
     owner_id: &str,
     active_only: Option<bool>,
 ) -> BridgeResult<Vec<Survey>> {
-    let surveys = if owner_id == "ALL" {
+    let sql = if owner_id == "ALL" {
         if active_only == Some(true) {
-            sqlx::query_as::<_, Survey>(
-                "SELECT * FROM surveys WHERE is_active = 1 ORDER BY created_at DESC",
-            )
-            .fetch_all(pool)
-            .await?
+            format!("SELECT {} FROM surveys WHERE is_active = 1 ORDER BY created_at DESC", SELECT_COLUMNS)
         } else {
-            sqlx::query_as::<_, Survey>(
-                "SELECT * FROM surveys ORDER BY created_at DESC",
-            )
-            .fetch_all(pool)
-            .await?
+            format!("SELECT {} FROM surveys ORDER BY created_at DESC", SELECT_COLUMNS)
         }
     } else {
         if active_only == Some(true) {
-            sqlx::query_as::<_, Survey>(
-                "SELECT * FROM surveys WHERE owner_id = ? AND is_active = 1 ORDER BY created_at DESC",
-            )
-            .bind(owner_id)
-            .fetch_all(pool)
-            .await?
+            format!("SELECT {} FROM surveys WHERE owner_id = ? AND is_active = 1 ORDER BY created_at DESC", SELECT_COLUMNS)
         } else {
-            sqlx::query_as::<_, Survey>(
-                "SELECT * FROM surveys WHERE owner_id = ? ORDER BY created_at DESC",
-            )
-            .bind(owner_id)
-            .fetch_all(pool)
-            .await?
+            format!("SELECT {} FROM surveys WHERE owner_id = ? ORDER BY created_at DESC", SELECT_COLUMNS)
         }
     };
 
-    Ok(surveys)
+    let mut query = sqlx::query_as::<_, Survey>(&sql);
+    if owner_id != "ALL" {
+        query = query.bind(owner_id);
+    }
+
+    Ok(query.fetch_all(pool).await?)
 }
 
 /// 稼働中（is_active = 1）の全アンケートを取得する。
 pub async fn find_active(pool: &MySqlPool) -> BridgeResult<Vec<Survey>> {
-    let surveys = sqlx::query_as::<_, Survey>(
-        "SELECT * FROM surveys WHERE is_active = 1 ORDER BY created_at DESC",
-    )
-    .fetch_all(pool)
-    .await?;
+    let sql = format!("SELECT {} FROM surveys WHERE is_active = 1 ORDER BY created_at DESC", SELECT_COLUMNS);
+    let surveys = sqlx::query_as::<_, Survey>(&sql)
+        .fetch_all(pool)
+        .await?;
 
     Ok(surveys)
 }


### PR DESCRIPTION
[修正内容]
- survey_repo.rs / response_repo.rs / log_repo.rs
  - SELECT * を廃止し、カラムを明示
  - DATETIME型カラムを CAST(... AS CHAR) に変換
  - これにより sqlx が String 型として正常にデコードできるようになり、一覧が空になる問題を解消