### PR TITLE
fix: DMChannel による AttributeError を修正

### DIFF
--- a/discord_bot/cogs/stream_comment_reset/logic.py
+++ b/discord_bot/cogs/stream_comment_reset/logic.py
@@ -48,6 +48,8 @@ class StreamCommentResetLogic:
         """メッセージが VoiceKeeper の寝落ち集計報告かどうかを判定する。"""
         if not message.author.bot:
             return False
+        if not isinstance(message.channel, discord.TextChannel):
+            return False
         if message.channel.name != STREAM_COMMENT_CHANNEL_NAME:
             return False
         if VOICE_KEEPER_REPORT_KEYWORD not in (message.content or ""):


### PR DESCRIPTION
is_voice_keeper_report で message.channel が TextChannel であることを確認 DM メッセージが到達しても name 属性参照でエラーが発生しないようにした