### PR TITLE
fix: 称号新規作成を廃止・大会作成フォーム拡張・navbar navリンク追加

### DIFF
--- a/discord_bot/routes/lobby.py
+++ b/discord_bot/routes/lobby.py
@@ -68,16 +68,24 @@ async def create_lobby():
 
     form = await request.form
     passcode = form.get('passcode')
-    mode = form.get('mode', 'free') # 'free' or 'tournament'
+    mode = form.get('mode', 'free')
     title = form.get('title', '新対戦ロビー')
     description = form.get('description', '').strip() or None
+    game_title_id = form.get('game_title_id')
+    bracket_format = form.get('bracket_format', 'single_elimination')
+    wins_required = form.get('wins_required', '1')
 
     if not passcode:
         await flash("合言葉は必須です", "error")
         return redirect(url_for('index'))
 
     try:
-        success = await LobbyService.create_room(passcode, int(user['id']), mode, title, description)
+        extra = {}
+        if mode == 'tournament' and game_title_id:
+            extra['game_title_id'] = int(game_title_id)
+            extra['bracket_format'] = bracket_format
+            extra['wins_required'] = int(wins_required)
+        success = await LobbyService.create_room(passcode, int(user['id']), mode, title, description, extra=extra if extra else None)
         if success:
             await flash(f"ロビー「{title}」を作成しました", "success")
             return redirect(url_for('lobby.view_lobby', passcode=passcode))

--- a/discord_bot/services/lobby_service.py
+++ b/discord_bot/services/lobby_service.py
@@ -28,7 +28,7 @@ class LobbyService:
         return res is not None and res.get("status") == "ok"
 
     @staticmethod
-    async def create_room(passcode: str, host_id: int, mode: str, title: str, description: Optional[str] = None, expires_in_hours: int = 24) -> bool:
+    async def create_room(passcode: str, host_id: int, mode: str, title: str, description: Optional[str] = None, expires_in_hours: int = 24, extra: Optional[Dict[str, Any]] = None) -> bool:
         """新規ロビーを作成する"""
         payload = {
             "passcode": passcode,
@@ -36,8 +36,10 @@ class LobbyService:
             "mode": mode,
             "title": title,
             "description": description,
-            "expires_in_hours": expires_in_hours
+            "expires_in_hours": expires_in_hours,
         }
+        if extra:
+            payload.update(extra)
         res = await bridge_client.request("POST", "/lobby/rooms", json=payload)
         return res is not None and res.get("status") == "ok"
 

--- a/discord_bot/static/js/dashboard_lobby.js
+++ b/discord_bot/static/js/dashboard_lobby.js
@@ -1,0 +1,42 @@
+// static/js/dashboard_lobby.js
+// Why: dashboard.html の大会作成フォーム、モード切替ロジックを分離。
+(function () {
+    'use strict';
+
+    const modeFree       = document.getElementById('mode-free');
+    const modeTournament = document.getElementById('mode-tournament');
+    const options        = document.getElementById('tournament-options');
+    const selectGame     = document.getElementById('select-game-title');
+    const bracketGroup   = document.getElementById('bracket-format-group');
+    const winsLabel      = document.getElementById('wins-label');
+
+    function onModeChange() {
+        const isTournament = modeTournament && modeTournament.checked;
+        if (options) options.style.display = isTournament ? 'block' : 'none';
+    }
+
+    function onGameChange() {
+        if (!selectGame) return;
+        const selected = selectGame.options[selectGame.selectedIndex];
+        const matchType = selected ? selected.dataset.matchType : '1v1';
+
+        if (matchType === 'multiplayer') {
+            // multiplayer は総当たり固定・レース数入力に切替
+            if (bracketGroup) bracketGroup.style.display = 'none';
+            if (winsLabel) winsLabel.textContent = 'レース数';
+            const bracketSelect = document.querySelector('select[name="bracket_format"]');
+            if (bracketSelect) bracketSelect.value = 'round_robin';
+        } else {
+            if (bracketGroup) bracketGroup.style.display = 'block';
+            if (winsLabel) winsLabel.textContent = 'n本先取';
+        }
+    }
+
+    modeFree       && modeFree.addEventListener('change', onModeChange);
+    modeTournament && modeTournament.addEventListener('change', onModeChange);
+    selectGame     && selectGame.addEventListener('change', onGameChange);
+
+    // 初期状態を反映
+    onModeChange();
+    onGameChange();
+})();

--- a/discord_bot/static/js/dashboard_titles.js
+++ b/discord_bot/static/js/dashboard_titles.js
@@ -110,19 +110,16 @@
         document.getElementById('modal-order').value = '0';
     }
 
-    document.getElementById('btn-new-title').addEventListener('click', () => {
-        document.getElementById('modal-title-heading').textContent = '新規称号を作成';
-        hideModal();
-        showModal();
-    });
     document.getElementById('modal-cancel').addEventListener('click', hideModal);
 
     document.getElementById('modal-save').addEventListener('click', async () => {
         const id = document.getElementById('modal-title-id').value;
+        if (!id) { alert('編集対象の称号が選択されていません'); return; }
         const name = document.getElementById('modal-name').value.trim();
         if (!name) { alert('称号名を入力してください'); return; }
 
         const body = {
+            id: parseInt(id),
             name,
             description: document.getElementById('modal-description').value.trim() || null,
             unlock_type: document.getElementById('modal-unlock-type').value,
@@ -131,7 +128,6 @@
             discord_role_id: document.getElementById('modal-role-id').value.trim() || null,
             display_order: parseInt(document.getElementById('modal-order').value) || 0,
         };
-        if (id) body.id = parseInt(id);
 
         await fetch('/tournament/api/titles/save', {
             method: 'POST',

--- a/discord_bot/templates/dashboard.html
+++ b/discord_bot/templates/dashboard.html
@@ -12,6 +12,14 @@
 <body>
     <nav class="navbar">
         <div class="navbar-brand"><i class="fas fa-robot"></i> Awaji Empire Agent</div>
+        <div style="display:flex; gap:8px; align-items:center; margin-left:auto; margin-right:16px;">
+            <a href="{{ url_for('tournament.index') }}" class="btn btn-sm btn-outline" style="border-color:rgba(255,255,255,0.4); color:white;">
+                <i class="fas fa-trophy"></i> 大会
+            </a>
+            <a href="{{ url_for('lounge.index') }}" class="btn btn-sm btn-outline" style="border-color:rgba(255,255,255,0.4); color:white;">
+                <i class="fas fa-flag-checkered"></i> ラウンジ
+            </a>
+        </div>
         <div class="user-menu">
             <img src="{{ user['avatar_url'] }}" class="user-avatar" alt="Avatar">
             <span>{{ user['name'] }}</span>
@@ -132,14 +140,39 @@
                         <div style="display: flex; gap: 10px; margin-top: 5px;">
                             <label
                                 style="flex: 1; border: 1px solid #dee2e6; border-radius: 6px; padding: 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; background-color: #fff; transition: all 0.2s;">
-                                <input type="radio" name="mode" value="free" checked style="margin-right: 8px;">
+                                <input type="radio" name="mode" value="free" id="mode-free" checked style="margin-right: 8px;">
                                 <strong>自由対戦モード</strong>
                             </label>
                             <label
                                 style="flex: 1; border: 1px solid #dee2e6; border-radius: 6px; padding: 10px; cursor: pointer; display: flex; align-items: center; justify-content: center; background-color: #fff; transition: all 0.2s;">
-                                <input type="radio" name="mode" value="tournament" style="margin-right: 8px;">
+                                <input type="radio" name="mode" value="tournament" id="mode-tournament" style="margin-right: 8px;">
                                 <strong style="color: #4a90e2;">大会モード</strong>
                             </label>
+                        </div>
+                    </div>
+                    <!-- 大会モード専用オプション -->
+                    <div id="tournament-options" style="width:100%; display:none; background:#f8f9ff; border:1px solid #d0d8ff; border-radius:6px; padding:1rem; margin-bottom:1rem;">
+                        <p style="font-size:.8rem; font-weight:600; color:#4a90e2; margin:0 0 .75rem;">大会オプション</p>
+                        <div style="display:flex; gap:12px; flex-wrap:wrap;">
+                            <div style="flex:2; min-width:160px;">
+                                <label class="lobby-form-label">ゲームタイトル</label>
+                                <select name="game_title_id" class="form-control" id="select-game-title">
+                                    {% for g in games %}
+                                    <option value="{{ g.id }}" data-match-type="{{ g.match_type }}">{{ g.name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div style="flex:1; min-width:120px;" id="bracket-format-group">
+                                <label class="lobby-form-label">対戦形式</label>
+                                <select name="bracket_format" class="form-control">
+                                    <option value="single_elimination">シングルイリミネーション</option>
+                                    <option value="round_robin">総当たり</option>
+                                </select>
+                            </div>
+                            <div style="flex:1; min-width:100px;">
+                                <label class="lobby-form-label" id="wins-label">n本先取 / レース数</label>
+                                <input type="number" name="wins_required" class="form-control" value="1" min="1" max="24">
+                            </div>
                         </div>
                     </div>
                     <div style="width: 100%; margin-top: 1rem;">
@@ -151,6 +184,7 @@
                         作成</button>
                 </form>
             </div>
+            <script src="{{ url_for('static', filename='js/dashboard_lobby.js') }}"></script>
 
             <div class="table-responsive">
                 <table class="table">
@@ -204,7 +238,6 @@
         <div class="card" id="title-management-card">
             <div class="card-header">
                 <h2 class="card-title">🏅 称号管理</h2>
-                <button class="btn btn-success btn-sm" id="btn-new-title"><i class="fas fa-plus"></i> 新規称号</button>
             </div>
 
             <!-- 自分の称号装備セクション -->

--- a/discord_bot/webapp.py
+++ b/discord_bot/webapp.py
@@ -9,6 +9,7 @@ from routes.lobby import lobby_bp
 from routes.tournament import tournament_bp
 from routes.lounge import lounge_bp
 from services.lobby_service import LobbyService
+from services.tournament_service import TournamentService
 from services.bridge_client import BridgeUnavailableError
 from services.survey_service import SurveyService
 from services.log_service import LogService
@@ -208,10 +209,10 @@ async def index():
         # LogService 経由で取得 (Rust Bridge を利用)
         logs = await LogService.get_recent_logs(None, limit=30)
         
-        # LobbyService 経由でアクティブなロビーを取得
         lobbies = await LobbyService.get_active_rooms()
+        games = await TournamentService.list_game_titles()
 
-        return await render_template('dashboard.html', user=user, surveys=surveys, logs=logs, lobbies=lobbies)
+        return await render_template('dashboard.html', user=user, surveys=surveys, logs=logs, lobbies=lobbies, games=games)
         
     except BridgeUnavailableError:
         current_app.logger.warning("Bridge unavailable on index: rendering maintenance page")


### PR DESCRIPTION
- 称号: 新規作成ボタン削除、編集のみ可能に変更（称号は大会優勝/ラウンジMMRで自動解除）
- dashboard navbar: 大会・ラウンジへのナビリンクを追加
- 大会作成フォーム: ゲームタイトル選択・対戦形式・n本先取/レース数フィールドを追加
- multiplayer タイトル選択時は総当たり固定・レース数入力に切替（dashboard_lobby.js）
- LobbyService.create_room: 大会オプション(game_title_id等)を extra で受け渡し