### PR TITLE
feat: ラウンジセッション一覧・ダッシュボードバナーを実装

### DIFF
--- a/database_bridge/src/api/handlers/lounge.rs
+++ b/database_bridge/src/api/handlers/lounge.rs
@@ -46,6 +46,16 @@ pub async fn create_session(
 }
 
 // ============================================================
+// GET /lounge/sessions  (アクティブセッション一覧)
+// ============================================================
+pub async fn list_sessions(State(pool): State<MySqlPool>) -> (StatusCode, Json<Value>) {
+    match lounge_repo::list_active_sessions(&pool).await {
+        Ok(sessions) => (StatusCode::OK, Json(json!(sessions))),
+        Err(e) => map_err(e),
+    }
+}
+
+// ============================================================
 // GET /lounge/sessions/{id}
 // ============================================================
 pub async fn get_session(

--- a/database_bridge/src/api/mod.rs
+++ b/database_bridge/src/api/mod.rs
@@ -87,7 +87,7 @@ fn title_routes() -> Router<AppState> {
 /// ラウンジ関連のルーティング。
 fn lounge_routes() -> Router<AppState> {
     Router::new()
-        .route("/sessions", post(handlers::lounge::create_session))
+        .route("/sessions", get(handlers::lounge::list_sessions).post(handlers::lounge::create_session))
         .route("/sessions/{id}", get(handlers::lounge::get_session))
         .route("/sessions/{id}/next-race", patch(handlers::lounge::next_race))
         .route("/sessions/{id}/finish", post(handlers::lounge::finish_session))

--- a/database_bridge/src/db/lounge_repo.rs
+++ b/database_bridge/src/db/lounge_repo.rs
@@ -73,6 +73,37 @@ pub async fn create_session(
     Ok(result.last_insert_id() as i64)
 }
 
+pub async fn list_active_sessions(pool: &MySqlPool) -> BridgeResult<Vec<serde_json::Value>> {
+    let rows = sqlx::query(
+        r#"SELECT ls.id, ls.room_id, ls.mode, ls.total_races, ls.current_race, ls.status,
+                  ls.host_id, u.username as host_name,
+                  CAST(ls.created_at AS CHAR) as created_at,
+                  COUNT(lsm.user_id) as member_count
+           FROM lounge_sessions ls
+           LEFT JOIN user_networks u ON u.discord_id = ls.host_id
+           LEFT JOIN lounge_session_members lsm ON lsm.session_id = ls.id
+           WHERE ls.status IN ('waiting', 'in_progress')
+           GROUP BY ls.id
+           ORDER BY ls.created_at DESC"#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    use sqlx::Row;
+    Ok(rows.iter().map(|r| serde_json::json!({
+        "id":           r.get::<i64, _>("id"),
+        "room_id":      r.get::<String, _>("room_id"),
+        "mode":         r.get::<String, _>("mode"),
+        "total_races":  r.get::<i8, _>("total_races"),
+        "current_race": r.get::<i8, _>("current_race"),
+        "status":       r.get::<String, _>("status"),
+        "host_id":      r.get::<i64, _>("host_id"),
+        "host_name":    r.get::<Option<String>, _>("host_name"),
+        "created_at":   r.get::<String, _>("created_at"),
+        "member_count": r.get::<i64, _>("member_count"),
+    })).collect())
+}
+
 pub async fn get_session(pool: &MySqlPool, session_id: i64) -> BridgeResult<LoungeSession> {
     sqlx::query_as::<_, LoungeSession>(
         r#"SELECT id, room_id, mode, total_races, current_race, status, host_id,

--- a/discord_bot/routes/lounge.py
+++ b/discord_bot/routes/lounge.py
@@ -29,7 +29,11 @@ async def index():
     if redir:
         return redir
     user = _current_user()
-    return await render_template("lounge.html", user=user, view="list")
+    try:
+        active_sessions = await LoungeService.list_active_sessions()
+    except Exception:
+        active_sessions = []
+    return await render_template("lounge.html", user=user, view="list", active_sessions=active_sessions)
 
 
 @lounge_bp.route("/sessions/<int:session_id>")

--- a/discord_bot/services/lounge_service.py
+++ b/discord_bot/services/lounge_service.py
@@ -5,6 +5,11 @@ from services.bridge_client import bridge_client
 
 class LoungeService:
     @staticmethod
+    async def list_active_sessions() -> List[Dict[str, Any]]:
+        res = await bridge_client.request("GET", "/lounge/sessions")
+        return res if res else []
+
+    @staticmethod
     async def create_session(room_id: str, host_id: int, mode: str = "ffa", total_races: int = 12) -> Optional[int]:
         res = await bridge_client.request("POST", "/lounge/sessions", json={
             "room_id": room_id, "host_id": host_id, "mode": mode, "total_races": total_races,

--- a/discord_bot/templates/dashboard.html
+++ b/discord_bot/templates/dashboard.html
@@ -29,6 +29,24 @@
     </nav>
 
     <div class="container">
+        {% for s in lounge_sessions %}
+        <div style="background:linear-gradient(135deg,#1a1a2e,#16213e); color:#fff; border-radius:var(--radius); padding:1rem 1.5rem; margin-bottom:1rem; display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px;">
+            <div style="display:flex; align-items:center; gap:12px;">
+                <span style="font-size:1.5rem;">🏎️</span>
+                <div>
+                    <strong style="font-size:1rem;">ラウンジ募集中！</strong>
+                    <div style="font-size:.85rem; opacity:.8; margin-top:2px;">
+                        ホスト: {{ s.get('host_name') or s.get('host_id') }}
+                        &nbsp;|&nbsp; {{ s.get('mode', 'FFA').upper() }}
+                        &nbsp;|&nbsp; {{ s.get('current_race', 0) }} / {{ s.get('total_races', 12) }} レース
+                        &nbsp;|&nbsp; {{ s.get('member_count', 0) }}人参加中
+                    </div>
+                </div>
+            </div>
+            <a href="{{ url_for('lounge.session_view', session_id=s.get('id')) }}" class="btn btn-success btn-sm">参加する</a>
+        </div>
+        {% endfor %}
+
         {% for cat, msg in get_flashed_messages(with_categories=true) %}
         <div class="alert {% if cat == 'error' %}alert-danger{% endif %}">
             <i class="fas {% if cat == 'error' %}fa-exclamation-circle{% else %}fa-check-circle{% endif %}"

--- a/discord_bot/templates/lounge.html
+++ b/discord_bot/templates/lounge.html
@@ -157,8 +157,43 @@
                     <button class="btn btn-success" id="btn-submit-session"><i class="fas fa-check"></i> 作成</button>
                 </div>
             </div>
-            <div class="card-body" style="color:var(--gray);">
-                セッション一覧は現在のバージョンでは管理側から直接URLで入場できます。
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>ホスト</th>
+                            <th width="80">モード</th>
+                            <th width="120">進行</th>
+                            <th width="80">参加者</th>
+                            <th width="80">状態</th>
+                            <th width="90">アクション</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for s in active_sessions %}
+                        <tr>
+                            <td><strong>{{ s.get('host_name') or s.get('host_id') }}</strong></td>
+                            <td><span class="badge badge-secondary">{{ s.get('mode', 'FFA').upper() }}</span></td>
+                            <td style="font-family:monospace;">{{ s.get('current_race', 0) }} / {{ s.get('total_races', 12) }} レース</td>
+                            <td style="text-align:center;">{{ s.get('member_count', 0) }}人</td>
+                            <td>
+                                <span class="badge {{ 'badge-warning' if s.get('status') == 'waiting' else 'badge-success' }}">
+                                    {{ '待機中' if s.get('status') == 'waiting' else '進行中' }}
+                                </span>
+                            </td>
+                            <td>
+                                <a href="{{ url_for('lounge.session_view', session_id=s.get('id')) }}" class="btn btn-primary btn-sm">入場</a>
+                            </td>
+                        </tr>
+                        {% else %}
+                        <tr>
+                            <td colspan="6" style="text-align:center; padding:2.5rem; color:var(--gray);">
+                                現在開催中のセッションはありません
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
         {% endif %}

--- a/discord_bot/webapp.py
+++ b/discord_bot/webapp.py
@@ -10,6 +10,7 @@ from routes.tournament import tournament_bp
 from routes.lounge import lounge_bp
 from services.lobby_service import LobbyService
 from services.tournament_service import TournamentService
+from services.lounge_service import LoungeService
 from services.bridge_client import BridgeUnavailableError
 from services.survey_service import SurveyService
 from services.log_service import LogService
@@ -211,8 +212,9 @@ async def index():
         
         lobbies = await LobbyService.get_active_rooms()
         games = await TournamentService.list_game_titles()
+        lounge_sessions = await LoungeService.list_active_sessions()
 
-        return await render_template('dashboard.html', user=user, surveys=surveys, logs=logs, lobbies=lobbies, games=games)
+        return await render_template('dashboard.html', user=user, surveys=surveys, logs=logs, lobbies=lobbies, games=games, lounge_sessions=lounge_sessions)
         
     except BridgeUnavailableError:
         current_app.logger.warning("Bridge unavailable on index: rendering maintenance page")


### PR DESCRIPTION
- GET /lounge/sessions エンドポイント追加（waiting/in_progress のセッションを返す）
- ラウンジ一覧画面にアクティブセッションテーブルを表示（ホスト・モード・進行・人数）
- ダッシュボードに「ラウンジ募集中！」バナーを追加（セッションごとに表示）