### PR TITLE
fix(lounge): SUM型パニック修正・順位申告のWS即時反映・自動再接続追加

### DIFF
--- a/database_bridge/src/api/handlers/lounge.rs
+++ b/database_bridge/src/api/handlers/lounge.rs
@@ -196,6 +196,8 @@ pub async fn report_score(
                 "type": "lounge.score_reported",
                 "race_id": race_id,
                 "user_id": payload.user_id,
+                "position": payload.position,
+                "is_disconnect": false,
             }).to_string());
             (StatusCode::OK, Json(json!({"status":"ok"})))
         },
@@ -222,6 +224,8 @@ pub async fn report_disconnect(
                 "type": "lounge.disconnect_reported",
                 "race_id": race_id,
                 "user_id": payload.user_id,
+                "position": null,
+                "is_disconnect": true,
             }).to_string());
             (StatusCode::OK, Json(json!({"status":"ok"})))
         },

--- a/database_bridge/src/db/lounge_repo.rs
+++ b/database_bridge/src/db/lounge_repo.rs
@@ -393,8 +393,9 @@ pub async fn approve_race_scores(pool: &MySqlPool, race_result_id: i64) -> Bridg
 
 pub async fn get_session_standings(pool: &MySqlPool, session_id: i64) -> BridgeResult<Vec<serde_json::Value>> {
     let rows = sqlx::query(
-        r#"SELECT lrs.user_id, u.username, SUM(lrs.points) as total_points,
-                  COUNT(CASE WHEN lrs.position = 1 THEN 1 END) as first_place_count
+        r#"SELECT lrs.user_id, u.username,
+                  CAST(COALESCE(SUM(lrs.points), 0) AS SIGNED) as total_points,
+                  CAST(COUNT(CASE WHEN lrs.position = 1 THEN 1 END) AS SIGNED) as first_place_count
            FROM lounge_race_scores lrs
            JOIN lounge_race_results lrr ON lrr.id = lrs.race_result_id
            LEFT JOIN user_networks u ON u.discord_id = lrs.user_id
@@ -417,7 +418,8 @@ pub async fn get_session_standings(pool: &MySqlPool, session_id: i64) -> BridgeR
 
 pub async fn get_team_standings(pool: &MySqlPool, session_id: i64) -> BridgeResult<Vec<serde_json::Value>> {
     let rows = sqlx::query(
-        r#"SELECT lt.tag, SUM(lrs.points) as team_points
+        r#"SELECT lt.tag,
+                  CAST(COALESCE(SUM(lrs.points), 0) AS SIGNED) as team_points
            FROM lounge_race_scores lrs
            JOIN lounge_race_results lrr ON lrr.id = lrs.race_result_id
            JOIN lounge_team_members ltm ON ltm.user_id = lrs.user_id

--- a/discord_bot/static/js/lounge.js
+++ b/discord_bot/static/js/lounge.js
@@ -382,27 +382,16 @@
     }
 
     // ============================================================
-    // WebSocket
+    // WebSocket（自動再接続付き）
     // ============================================================
     const wsProto = location.protocol === 'https:' ? 'wss' : 'ws';
-    const ws = new WebSocket(`${wsProto}://${location.host}/ws/hyouibana`);
+    let ws = null;
+    let wsReconnectTimer = null;
 
-    ws.addEventListener('open', () => {
-        console.log('[Lounge WS] connected');
-    });
-    ws.addEventListener('error', (e) => {
-        console.warn('[Lounge WS] error', e);
-    });
-
-    ws.addEventListener('message', (e) => {
-        let msg;
-        try { msg = JSON.parse(e.data); } catch (_) { return; }
-
+    function handleWsMessage(msg) {
         const msgSid = Number(msg.session_id);
 
         if (msg.type === 'lounge.race_created' && msgSid === SESSION_ID) {
-            // ゲストはWSでモーダルを開く。ホストは既にopenReportPhaseを呼んでいるが、
-            // まだcurrentRaceIdが未設定の場合（リロード直後など）は開く
             if (!IS_HOST || !currentRaceId) {
                 openReportPhase(msg.race_id, msg.course_name, msg.race_number);
             }
@@ -411,12 +400,15 @@
             }
         }
 
-        if (msg.type === 'lounge.score_reported' && Number(msg.race_id) === currentRaceId) {
-            loadSubmissions(currentRaceId);
-        }
-
-        if (msg.type === 'lounge.disconnect_reported' && Number(msg.race_id) === currentRaceId) {
-            loadSubmissions(currentRaceId);
+        // 申告データをWSメッセージから直接反映（HTTPフェッチ不要）
+        if ((msg.type === 'lounge.score_reported' || msg.type === 'lounge.disconnect_reported')
+                && Number(msg.race_id) === currentRaceId) {
+            submissionState[String(msg.user_id)] = {
+                submitted: true,
+                position: msg.position ?? null,
+                is_disconnect: msg.is_disconnect ?? false,
+            };
+            renderSubmissions();
         }
 
         if (msg.type === 'lounge.race_advanced' && msgSid === SESSION_ID) {
@@ -434,5 +426,31 @@
             hideModal();
             showResultModal();
         }
-    });
+    }
+
+    function connectWs() {
+        if (wsReconnectTimer) { clearTimeout(wsReconnectTimer); wsReconnectTimer = null; }
+        ws = new WebSocket(`${wsProto}://${location.host}/ws/hyouibana`);
+
+        ws.addEventListener('open', () => {
+            console.log('[Lounge WS] connected');
+        });
+
+        ws.addEventListener('message', (e) => {
+            let msg;
+            try { msg = JSON.parse(e.data); } catch (_) { return; }
+            handleWsMessage(msg);
+        });
+
+        ws.addEventListener('error', (e) => {
+            console.warn('[Lounge WS] error', e);
+        });
+
+        ws.addEventListener('close', () => {
+            console.warn('[Lounge WS] disconnected, reconnecting in 3s...');
+            wsReconnectTimer = setTimeout(connectWs, 3000);
+        });
+    }
+
+    connectWs();
 })();


### PR DESCRIPTION
- lounge_repo: SUM()/COUNT()をCAST(... AS SIGNED)でi64デコードパニックを修正
- lounge.rs: score_reported/disconnect_reportedにposition・is_disconnectを追加
- lounge.js: WS受信時にHTTPフェッチなしでsubmissionStateを直接更新し即時反映
- lounge.js: WS切断時3秒後自動再接続を実装