### PR TITLE
fix(lounge): モーダルから抜け出せない問題を修正

### DIFF
--- a/discord_bot/static/js/lounge.js
+++ b/discord_bot/static/js/lounge.js
@@ -298,7 +298,10 @@
             try {
                 const res  = await fetch(`/lounge/api/sessions/${SESSION_ID}/races/${currentRaceId}/finalize`, { method: 'POST' });
                 const data = await res.json();
-                if (data.status !== 'ok') {
+                if (data.status === 'ok') {
+                    // API成功時点で即座にモーダルを閉じる（WS到着を待たない）
+                    hideModal();
+                } else {
                     alert('確定に失敗しました');
                     btnFinalize.disabled = false;
                     btnFinalize.innerHTML = '<i class="fas fa-check-double"></i> 結果確定・次のレースへ';
@@ -308,6 +311,16 @@
                 btnFinalize.disabled = false;
                 btnFinalize.innerHTML = '<i class="fas fa-check-double"></i> 結果確定・次のレースへ';
             }
+        });
+    }
+
+    // モーダル×ボタン・オーバーレイクリックで閉じる
+    const btnClose = $id('modal-btn-close');
+    if (btnClose) btnClose.addEventListener('click', hideModal);
+    const overlay = $id('race-modal-overlay');
+    if (overlay) {
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay) hideModal();
         });
     }
 

--- a/discord_bot/templates/lounge.html
+++ b/discord_bot/templates/lounge.html
@@ -175,7 +175,10 @@
                         <div style="font-size:.8rem; opacity:.7;" id="modal-header-label">レース設定</div>
                         <div style="font-size:1.1rem; font-weight:700;" id="modal-course-name">—</div>
                     </div>
-                    <span style="font-size:.85rem; opacity:.7;" id="modal-race-num"></span>
+                    <div style="display:flex; align-items:center; gap:12px;">
+                        <span style="font-size:.85rem; opacity:.7;" id="modal-race-num"></span>
+                        <button id="modal-btn-close" title="閉じる" style="background:none; border:none; color:rgba(255,255,255,.6); font-size:1.3rem; cursor:pointer; line-height:1; padding:2px 4px;">&times;</button>
+                    </div>
                 </div>
 
                 <div style="padding:1.25rem 1.5rem;">


### PR DESCRIPTION
- ホストのfinalize成功時にWS待ちせず即座にhideModal()
- モーダルヘッダーに×ボタンを追加（全員が手動で閉じられる）
- オーバーレイ背景クリックでもモーダルを閉じる