### PR TITLE
feat(dashboard): ラウンジMMR表示・セッション終了モーダル修正

### DIFF
--- a/discord_bot/routes/lounge.py
+++ b/discord_bot/routes/lounge.py
@@ -61,6 +61,7 @@ async def session_view(session_id: int):
             members=members,
             view="session",
             is_host=is_host,
+            session_finished=(session_data.get("status") == "finished"),
         )
     except BridgeUnavailableError:
         return await render_template("maintenance.html"), 503

--- a/discord_bot/static/js/lounge.js
+++ b/discord_bot/static/js/lounge.js
@@ -282,8 +282,10 @@
                     alert('終了処理に失敗しました');
                     btnModalFinish.disabled = false;
                     btnModalFinish.innerHTML = '<i class="fas fa-flag-checkered"></i> 終了確定・MMR反映';
+                    return;
                 }
-                // 成功時は WS の lounge.session_finished で result_modal を表示する
+                // API成功時点でホストはすぐに表示（WSを待たない）
+                showResultModal();
             } catch (err) {
                 console.error(err);
                 alert('通信エラーが発生しました');
@@ -433,4 +435,9 @@
     // 初期ロード
     loadFinalScores();
     connectWs();
+
+    // セッションが既に終了済みの状態でページを開いた場合はすぐ結果モーダルを表示
+    if (SESSION_FINISHED) {
+        showResultModal();
+    }
 })();

--- a/discord_bot/templates/dashboard.html
+++ b/discord_bot/templates/dashboard.html
@@ -54,6 +54,27 @@
         </div>
         {% endfor %}
 
+        {% if lounge_player and lounge_player.get('total_sessions', 0) > 0 %}
+        <div style="background:#fff; border:1px solid var(--border-color); border-radius:var(--radius); padding:1rem 1.5rem; margin-bottom:1rem; display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px;">
+            <div style="display:flex; align-items:center; gap:16px;">
+                <span style="font-size:1.5rem;">🎮</span>
+                <div>
+                    <div style="font-size:.8rem; color:var(--gray); margin-bottom:2px;">ラウンジ MMR</div>
+                    <div style="display:flex; align-items:baseline; gap:6px;">
+                        <span style="font-size:1.6rem; font-weight:800; color:var(--accent); font-family:monospace; line-height:1;">{{ lounge_player.get('mmr', 1000) }}</span>
+                        <span style="font-size:.85rem; color:var(--gray);">/ 最高 {{ lounge_player.get('peak_mmr', 1000) }}</span>
+                    </div>
+                </div>
+                <div style="border-left:1px solid var(--border-color); padding-left:16px; color:var(--gray); font-size:.82rem; line-height:1.8;">
+                    <div>参加セッション: <strong>{{ lounge_player.get('total_sessions', 0) }}</strong> 回</div>
+                </div>
+            </div>
+            <a href="{{ url_for('lounge.index') }}" class="btn btn-primary btn-sm">
+                <i class="fas fa-flag-checkered"></i> ラウンジへ
+            </a>
+        </div>
+        {% endif %}
+
         {% for cat, msg in get_flashed_messages(with_categories=true) %}
         <div class="alert {% if cat == 'error' %}alert-danger{% endif %}">
             <i class="fas {% if cat == 'error' %}fa-exclamation-circle{% else %}fa-check-circle{% endif %}"

--- a/discord_bot/templates/lounge.html
+++ b/discord_bot/templates/lounge.html
@@ -302,6 +302,7 @@
     <script>
         const SESSION_ID = {{ lounge_session.id if lounge_session else 'null' }};
         const IS_HOST = {{ 'true' if is_host is defined and is_host else 'false' }};
+        const SESSION_FINISHED = {{ 'true' if session_finished is defined and session_finished else 'false' }};
         const MY_USER_ID = '{{ user["id"] }}';
         const MEMBERS = {
             {% if members is defined %}

--- a/discord_bot/webapp.py
+++ b/discord_bot/webapp.py
@@ -250,8 +250,9 @@ async def index():
         lobbies = await LobbyService.get_active_rooms()
         games = await TournamentService.list_game_titles()
         lounge_sessions = await LoungeService.list_active_sessions()
+        lounge_player = await LoungeService.get_player(int(user['id']))
 
-        return await render_template('dashboard.html', user=user, surveys=surveys, logs=logs, lobbies=lobbies, games=games, lounge_sessions=lounge_sessions)
+        return await render_template('dashboard.html', user=user, surveys=surveys, logs=logs, lobbies=lobbies, games=games, lounge_sessions=lounge_sessions, lounge_player=lounge_player)
         
     except BridgeUnavailableError:
         current_app.logger.warning("Bridge unavailable on index: rendering maintenance page")


### PR DESCRIPTION
- ダッシュボードにラウンジMMRカードを追加（ラウンジ参加履歴がある場合のみ表示）
- セッション終了モーダルが自動表示されない問題を修正:
  - ホスト: finish API 成功時点でモーダルを即時表示（WS待ち不要）
  - 全員: SESSION_FINISHED フラグを template から JS に渡し、 終了済みセッションにページロードした際もモーダルを表示