### PR TITLE
fix(lounge): 覇者称号未付与・非ホストの結果モーダル未表示を修正

### DIFF
--- a/discord_bot/routes/lounge.py
+++ b/discord_bot/routes/lounge.py
@@ -141,12 +141,26 @@ async def _do_finish_session(session_id: int):
     results = res.get("results", [])
     all_titles = await TitleService.list_all()
 
+    # 1位（セッション優勝者）を特定
+    winner_uid = next(
+        (e.get("user_id") for e in results if e.get("final_rank") == 1),
+        None,
+    )
+
     for entry in results:
         uid = entry.get("user_id")
         new_mmr = entry.get("new_mmr", 0)
         if not uid:
             continue
+
+        # MMR ベースのランク称号付与
         newly_granted_ids = await TitleService.grant_rank(uid, new_mmr)
+
+        # 1位ならセッション優勝称号（tournament_win タイプ）も付与
+        if uid == winner_uid:
+            win_ids = await TitleService.grant_tournament_win(uid)
+            newly_granted_ids = list(set(newly_granted_ids + win_ids))
+
         for title_id in newly_granted_ids:
             active = await TitleService.get_active(uid)
             granted_title = next((t for t in all_titles if t["id"] == title_id), None)
@@ -205,6 +219,16 @@ async def api_my_result(session_id: int):
         "rank_name":       active_title_name or "—",
         "is_winner":       final_rank == 1,
     })
+
+
+@lounge_bp.route("/api/sessions/<int:session_id>/status")
+async def api_session_status(session_id: int):
+    """セッションのステータスのみを返す（非ホストのモーダル自動表示用）。"""
+    if not _current_user():
+        return jsonify({}), 401
+    session_data = await LoungeService.get_session(session_id)
+    status = session_data.get("status", "unknown") if session_data else "unknown"
+    return jsonify({"status": status})
 
 
 @lounge_bp.route("/api/sessions/<int:session_id>/standings")

--- a/discord_bot/static/js/lounge.js
+++ b/discord_bot/static/js/lounge.js
@@ -311,6 +311,8 @@
     // セッション終了結果モーダル
     // ============================================================
     async function showResultModal() {
+        if (resultModalShown) return;
+        resultModalShown = true;
         closeFinalReportModal();
         const overlay = $id('result-modal-overlay');
         if (!overlay) { location.href = '/'; return; }
@@ -391,16 +393,31 @@
         }
     }
 
+    // 結果モーダルの二重表示防止フラグ
+    let resultModalShown = false;
+
     // WS切断中にポーリングで状態を補完するタイマー
     let pollTimer = null;
 
     function startPolling() {
         if (pollTimer) return;
-        pollTimer = setInterval(loadFinalScores, 10000);
+        pollTimer = setInterval(pollTick, 10000);
     }
 
     function stopPolling() {
         if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    }
+
+    async function pollTick() {
+        await loadFinalScores();
+        // セッションが終了済みになっていたらモーダルを表示
+        if (!resultModalShown) {
+            try {
+                const res  = await fetch(`/lounge/api/sessions/${SESSION_ID}/status`);
+                const data = await res.json();
+                if (data.status === 'finished') showResultModal();
+            } catch (_) {}
+        }
     }
 
     function connectWs() {
@@ -411,7 +428,7 @@
             console.log('[Lounge WS] connected');
             stopPolling();
             // 切断中に発生した変化を再取得して画面を最新化
-            loadFinalScores();
+            pollTick();
         });
 
         ws.addEventListener('message', (e) => {


### PR DESCRIPTION
[称号]
- _do_finish_session でセッション1位に grant_tournament_win を追加
- MMRベースの grant_rank に加えて tournament_win タイプ称号も付与対象に

[結果モーダル]
- resultModalShown フラグで二重表示を防止
- WS再接続・ポーリング時に /api/sessions/{id}/status を確認し finished になっていれば即座に結果モーダルを表示
- WS が届かなかった場合でも最大10秒以内に自動表示