### PR TITLE
fix(event): イベント設定の保存・復元が機能しない問題を修正

### DIFF
--- a/database_bridge/src/api/handlers/event.rs
+++ b/database_bridge/src/api/handlers/event.rs
@@ -125,6 +125,69 @@ pub async fn get_event_by_survey(
 }
 
 // ============================================================
+// イベント更新 (PUT /events/:id)
+// ============================================================
+
+#[derive(Deserialize)]
+pub struct UpdateEventRequest {
+    pub title: String,
+    pub fee: Option<i32>,
+    pub notes: Option<String>,
+    pub location: Option<String>,
+    pub event_date: Option<String>,
+    pub end_date: Option<String>,
+    pub application_deadline: Option<String>,
+    pub sessions: Option<Vec<CreateSessionRequest>>,
+}
+
+/// PUT /events/:id
+pub async fn update_event(
+    State(pool): State<MySqlPool>,
+    Path(event_id): Path<i32>,
+    Json(payload): Json<UpdateEventRequest>,
+) -> (StatusCode, Json<Value>) {
+    if let Err(e) = event_repo::update_event(
+        &pool,
+        event_id,
+        &payload.title,
+        payload.fee,
+        payload.notes.as_deref(),
+        payload.location.as_deref(),
+        payload.event_date.as_deref(),
+        payload.end_date.as_deref(),
+        payload.application_deadline.as_deref(),
+    )
+    .await
+    {
+        return internal_error(e);
+    }
+
+    // 部を全削除して再挿入
+    if let Err(e) = event_repo::delete_sessions_by_event(&pool, event_id).await {
+        return internal_error(e);
+    }
+    if let Some(sessions) = payload.sessions {
+        for s in sessions {
+            if let Err(e) = event_repo::insert_session(
+                &pool,
+                event_id,
+                &s.name,
+                s.event_date.as_deref(),
+                s.end_date.as_deref(),
+                s.location.as_deref(),
+                s.capacity,
+            )
+            .await
+            {
+                return internal_error(e);
+            }
+        }
+    }
+
+    (StatusCode::OK, Json(json!({"status": "ok"})))
+}
+
+// ============================================================
 // イベントステータス更新
 // ============================================================
 

--- a/database_bridge/src/api/mod.rs
+++ b/database_bridge/src/api/mod.rs
@@ -105,7 +105,7 @@ fn lounge_routes() -> Router<AppState> {
 fn event_routes() -> Router<AppState> {
     Router::new()
         .route("/", post(handlers::event::create_event))
-        .route("/{id}", get(handlers::event::get_event))
+        .route("/{id}", get(handlers::event::get_event).put(handlers::event::update_event))
         .route("/{id}/status", patch(handlers::event::update_event_status))
         .route("/{id}/participants", post(handlers::event::upsert_participant).get(handlers::event::list_participants))
         .route("/{id}/auto-assign", post(handlers::event::auto_assign))

--- a/database_bridge/src/db/event_repo.rs
+++ b/database_bridge/src/db/event_repo.rs
@@ -70,6 +70,34 @@ pub async fn find_event_by_survey(pool: &MySqlPool, survey_id: i32) -> BridgeRes
     )
 }
 
+pub async fn update_event(
+    pool: &MySqlPool,
+    event_id: i32,
+    title: &str,
+    fee: Option<i32>,
+    notes: Option<&str>,
+    location: Option<&str>,
+    event_date: Option<&str>,
+    end_date: Option<&str>,
+    application_deadline: Option<&str>,
+) -> BridgeResult<()> {
+    sqlx::query(
+        "UPDATE events SET title=?, fee=?, notes=?, location=?, event_date=?, end_date=?, application_deadline=? \
+         WHERE id=?",
+    )
+    .bind(title)
+    .bind(fee)
+    .bind(notes)
+    .bind(location)
+    .bind(event_date)
+    .bind(end_date)
+    .bind(application_deadline)
+    .bind(event_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 pub async fn update_event_status(pool: &MySqlPool, event_id: i32, status: &str) -> BridgeResult<()> {
     sqlx::query("UPDATE events SET status = ? WHERE id = ?")
         .bind(status)

--- a/discord_bot/routes/survey.py
+++ b/discord_bot/routes/survey.py
@@ -84,7 +84,8 @@ async def edit_survey(survey_id):
         return "Forbidden", 403
 
     questions = parse_questions(survey['questions'])
-    return await render_template('edit.html', user=user, survey=survey, questions=questions)
+    event_info = await EventService.get_event_by_survey(survey_id)
+    return await render_template('edit.html', user=user, survey=survey, questions=questions, event_info=event_info)
 
 
 @survey_bp.route('/save_survey', methods=['POST'])
@@ -97,6 +98,7 @@ async def save_survey():
     sid = form.get('survey_id')
     title = form.get('title')
     q_json = form.get('questions_json')
+    event_settings_raw = form.get('event_settings_json', '')
 
     try:
         # オーナーチェック
@@ -108,6 +110,45 @@ async def save_survey():
         if not success:
             return "Error", 500
         await LogService.log_operation(None, user['id'], user['name'], "UPDATE", f"ID:{sid} を更新")
+
+        # イベント設定の保存
+        if event_settings_raw:
+            try:
+                es = json.loads(event_settings_raw)
+            except (json.JSONDecodeError, ValueError):
+                es = {}
+
+            existing_event = await EventService.get_event_by_survey(int(sid))
+
+            if es.get('is_event_form'):
+                sessions = es.get('sessions') or []
+                fee_raw = es.get('fee')
+                fee = int(fee_raw) if fee_raw else None
+                if existing_event is None:
+                    await EventService.create_event(
+                        survey_id=int(sid),
+                        title=title,
+                        fee=fee,
+                        notes=es.get('notes') or None,
+                        location=es.get('location') or None,
+                        event_date=es.get('event_date') or None,
+                        end_date=es.get('end_date') or None,
+                        application_deadline=es.get('application_deadline') or None,
+                        sessions=sessions,
+                    )
+                else:
+                    await EventService.update_event(
+                        event_id=existing_event['event']['id'],
+                        title=title,
+                        fee=fee,
+                        notes=es.get('notes') or None,
+                        location=es.get('location') or None,
+                        event_date=es.get('event_date') or None,
+                        end_date=es.get('end_date') or None,
+                        application_deadline=es.get('application_deadline') or None,
+                        sessions=sessions,
+                    )
+
     except Exception as e:
         return f"Error: {e}", 500
 

--- a/discord_bot/services/event_service.py
+++ b/discord_bot/services/event_service.py
@@ -51,6 +51,35 @@ class EventService:
         return res
 
     @staticmethod
+    async def update_event(
+        event_id: int,
+        title: str,
+        fee: Optional[int] = None,
+        notes: Optional[str] = None,
+        location: Optional[str] = None,
+        event_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        application_deadline: Optional[str] = None,
+        sessions: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        """イベント情報（部含む）を上書き更新する。"""
+        res = await bridge_client.request(
+            "PUT",
+            f"/events/{event_id}",
+            json={
+                "title": title,
+                "fee": fee,
+                "notes": notes,
+                "location": location,
+                "event_date": event_date,
+                "end_date": end_date,
+                "application_deadline": application_deadline,
+                "sessions": sessions or [],
+            },
+        )
+        return res is not None and res.get("status") == "ok"
+
+    @staticmethod
     async def update_status(event_id: int, status: str) -> bool:
         """イベントステータスを更新する。status: draft|open|closed"""
         res = await bridge_client.request(

--- a/discord_bot/static/js/edit_survey.js
+++ b/discord_bot/static/js/edit_survey.js
@@ -276,9 +276,39 @@ document.getElementById('surveyForm').addEventListener('submit', () => {
 
     let sessions = [];
 
+    // 既存のイベント設定を復元
+    const existingJson = checkbox.dataset.eventInfo;
+    if (existingJson) {
+        try {
+            const existing = JSON.parse(existingJson);
+            const ev = existing.event || {};
+            const evSessions = existing.sessions || [];
+
+            if (document.getElementById('event-fee'))      document.getElementById('event-fee').value      = ev.fee ?? '';
+            if (document.getElementById('event-deadline')) document.getElementById('event-deadline').value = ev.application_deadline ?? '';
+            if (document.getElementById('event-date'))     document.getElementById('event-date').value     = ev.event_date ?? '';
+            if (document.getElementById('event-end-date')) document.getElementById('event-end-date').value = ev.end_date ?? '';
+            if (document.getElementById('event-location')) document.getElementById('event-location').value = ev.location ?? '';
+            if (document.getElementById('event-notes'))    document.getElementById('event-notes').value    = ev.notes ?? '';
+
+            sessions = evSessions.map(s => ({
+                name: s.name || '',
+                event_date: s.event_date || '',
+                end_date: s.end_date || '',
+                location: s.location || '',
+                capacity: s.capacity ?? '',
+            }));
+
+            section.style.display = 'block';
+            renderSessions();
+            syncEventJson();
+        } catch (_) {}
+    }
+
     checkbox.addEventListener('change', () => {
         section.style.display = checkbox.checked ? 'block' : 'none';
         if (checkbox.checked && sessions.length === 0) addSession();
+        syncEventJson();
     });
 
     document.getElementById('btn-add-session')?.addEventListener('click', addSession);

--- a/discord_bot/templates/edit.html
+++ b/discord_bot/templates/edit.html
@@ -28,7 +28,9 @@
                 </div>
                 <div class="form-group" style="margin-top:1rem; padding-top:1rem; border-top:1px solid var(--border-color);">
                     <label class="event-checkbox-label">
-                        <input type="checkbox" id="is-event-form">
+                        <input type="checkbox" id="is-event-form"
+                            {% if event_info %}checked{% endif %}
+                            data-event-info="{{ event_info | tojson | e if event_info else '' }}">
                         <i class="fas fa-calendar-check" style="color:var(--accent-blue);"></i>
                         イベント参加フォームとして作成する
                     </label>


### PR DESCRIPTION
- save_survey で event_settings_json を受け取り create/update_event を呼ぶよう修正
- EventService.update_event を追加（部を全削除→再挿入で更新）
- Rust側に PUT /events/:id ハンドラーと update_event repo を追加
- edit_survey でイベント編集画面を開いた時に既存設定（部・費用・日時等）を復元