### PR TITLE
fix(event): 参加・不参加の判定ロジックを修正

### DIFF
--- a/database_bridge/src/db/event_repo.rs
+++ b/database_bridge/src/db/event_repo.rs
@@ -314,16 +314,16 @@ pub async fn auto_assign(pool: &MySqlPool, event_id: i32) -> BridgeResult<()> {
             continue;
         }
 
+        // NULL = 不参加、"[]" = 参加(部なし)、"[1,2]" = 希望部あり
+        if p.preferred_session_ids.is_none() {
+            continue;
+        }
+
         let preferred: Vec<i32> = p
             .preferred_session_ids
             .as_deref()
             .and_then(|s| serde_json::from_str(s).ok())
             .unwrap_or_default();
-
-        // 不参加（希望なし）
-        if preferred.is_empty() {
-            continue;
-        }
 
         let mut assigned: Option<i32> = None;
 

--- a/discord_bot/routes/survey.py
+++ b/discord_bot/routes/survey.py
@@ -312,9 +312,10 @@ async def submit_response():
             attending = form.get('event_attending')  # "yes" or "no"
             if attending == 'yes':
                 raw = form.getlist('event_preferred_sessions[]')
+                # 空リスト [] = 参加・部なし。None = 不参加。両者を区別する
                 preferred_ids = [int(v) for v in raw if v.isdigit()]
             else:
-                preferred_ids = None
+                preferred_ids = None  # 明示的な不参加
             await EventService.register_participant(
                 event_id=event['id'],
                 user_id=int(u_id),

--- a/discord_bot/services/event_service.py
+++ b/discord_bot/services/event_service.py
@@ -107,7 +107,8 @@ class EventService:
         """参加者を登録し、個人確認ページ用 access_token を返す。"""
         import json as _json
         token = secrets.token_urlsafe(32)
-        preferred_json = _json.dumps(preferred_session_ids) if preferred_session_ids else None
+        # None=不参加、[]=参加(部なし)、[1,2,...]=希望部あり — None のみ NULL に変換
+        preferred_json = _json.dumps(preferred_session_ids) if preferred_session_ids is not None else None
         res = await bridge_client.request(
             "POST",
             f"/events/{event_id}/participants",

--- a/discord_bot/templates/event_admin.html
+++ b/discord_bot/templates/event_admin.html
@@ -96,7 +96,13 @@
                 <tr id="row-{{ p['id'] }}">
                     <td style="font-weight:bold;">{{ p['username'] }}</td>
                     <td style="color:var(--gray); font-size:.85rem;">
-                        {{ p['preferred_session_ids'] or '不参加' }}
+                        {% if p['preferred_session_ids'] is none %}
+                            不参加
+                        {% elif p['preferred_session_ids'] == '[]' %}
+                            —
+                        {% else %}
+                            {{ p['preferred_session_ids'] }}
+                        {% endif %}
                     </td>
                     <td>
                         <select class="form-control select-session" style="width:auto; min-width:90px;"


### PR DESCRIPTION
- [] (空リスト) = 参加(部なし)、NULL = 不参加 として区別
- register_participant: preferred_session_ids is not None で NULL 変換
- submit_response: attending=yes なら [] でも None にしない
- auto_assign: preferred_session_ids が NULL のみスキップ
- event_admin.html: NULL を '不参加'、'[]' を '—' と表示