### PR TITLE
fix(event): 不参加バグ修正 & 管理画面にアンケート回答列を追加

### DIFF
--- a/discord_bot/routes/event.py
+++ b/discord_bot/routes/event.py
@@ -116,12 +116,20 @@ async def admin(event_id: int):
 
         participants = await EventService.list_participants(event_id)
 
-        # survey responses から username を補完
-        responses = await SurveyService.get_responses(None, event['survey_id'])
-        resp_map  = {str(r['id']): r.get('user_name', '') for r in responses}
+        # survey responses から username と回答内容を補完
+        survey      = await SurveyService.get_survey(None, event['survey_id'])
+        responses   = await SurveyService.get_responses(None, event['survey_id'])
+        resp_map    = {str(r['id']): r for r in responses}
         for p in participants:
+            resp = resp_map.get(str(p.get('response_id', '')), {})
             if not p.get('username'):
-                p['username'] = resp_map.get(str(p.get('response_id', '')), f"ID:{p['user_id']}")
+                p['username'] = resp.get('user_name', f"ID:{p['user_id']}")
+            import json as _json
+            raw_answers = resp.get('answers', '{}')
+            p['answers'] = _json.loads(raw_answers) if isinstance(raw_answers, str) else (raw_answers or {})
+
+        from common.survey_utils import parse_questions
+        survey_questions = parse_questions(survey['questions']) if survey else []
 
         # 部ごとの残席計算
         session_stats = {}
@@ -143,6 +151,7 @@ async def admin(event_id: int):
         sessions=sessions,
         participants=participants,
         session_stats=session_stats,
+        survey_questions=survey_questions,
     )
 
 

--- a/discord_bot/routes/survey.py
+++ b/discord_bot/routes/survey.py
@@ -320,7 +320,7 @@ async def submit_response():
                 event_id=event['id'],
                 user_id=int(u_id),
                 response_id=response_id,
-                preferred_session_ids=preferred_ids if preferred_ids else None,
+                preferred_session_ids=preferred_ids,  # [] = 参加(部なし), None = 不参加
             )
 
     return await render_template('submitted.html')

--- a/discord_bot/templates/event_admin.html
+++ b/discord_bot/templates/event_admin.html
@@ -86,6 +86,7 @@
                         <th>希望</th>
                         <th>割り当て部</th>
                         <th>状態</th>
+                        {% for q in survey_questions %}<th style="font-size:.8rem; white-space:nowrap;">{{ q.text }}</th>{% endfor %}
                         <th>個人メモ</th>
                         <th>通知</th>
                         <th></th>
@@ -122,6 +123,12 @@
                             <option value="waitlist" {% if p['approval']=='waitlist' %}selected{% endif %}>補欠</option>
                         </select>
                     </td>
+                    {% for q in survey_questions %}
+                    {% set ans = p['answers'].get(loop.index0 | string, '') %}
+                    <td style="font-size:.85rem; color:var(--gray);">
+                        {% if ans is iterable and ans is not string %}{{ ans | join(', ') }}{% else %}{{ ans }}{% endif %}
+                    </td>
+                    {% endfor %}
                     <td>
                         <input type="text" class="form-control" style="min-width:120px; width:160px; font-size:.85rem;"
                                value="{{ p['personal_note'] or '' }}"
@@ -142,7 +149,7 @@
                     </td>
                 </tr>
                 {% else %}
-                <tr><td colspan="7" style="text-align:center; padding:2rem; color:var(--gray);">応募者はいません</td></tr>
+                <tr><td colspan="{{ 7 + survey_questions | length }}" style="text-align:center; padding:2rem; color:var(--gray);">応募者はいません</td></tr>
                 {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
- submit_response: preferred_ids を None 変換しないよう修正（[]と Noneを区別）
- admin route: responses から answers を取得し participants に付加
- event_admin.html: アンケート質問ごとに回答列を動的生成