### PR TITLE
fix(event): auto_assign の部なしイベント対応とログ追加

### DIFF
--- a/database_bridge/src/db/event_repo.rs
+++ b/database_bridge/src/db/event_repo.rs
@@ -325,6 +325,12 @@ pub async fn auto_assign(pool: &MySqlPool, event_id: i32) -> BridgeResult<()> {
             .and_then(|s| serde_json::from_str(s).ok())
             .unwrap_or_default();
 
+        // 部なしイベント: 参加意思あり(preferred_session_ids not null)なら即 accepted
+        if sessions.is_empty() {
+            update_participant_approval(pool, p.id, "accepted", None, None).await?;
+            continue;
+        }
+
         let mut assigned: Option<i32> = None;
 
         // 希望順に空き確認
@@ -340,8 +346,8 @@ pub async fn auto_assign(pool: &MySqlPool, event_id: i32) -> BridgeResult<()> {
             }
         }
 
-        // 希望部が全滅なら空き部を探す（部制あり）
-        if assigned.is_none() && !sessions.is_empty() {
+        // 希望部が全滅なら空き部を探す
+        if assigned.is_none() {
             for sess in &sessions {
                 let used = *counts.get(&sess.id).unwrap_or(&0);
                 let has_space = sess.capacity.map_or(true, |cap| used < cap);

--- a/discord_bot/routes/event.py
+++ b/discord_bot/routes/event.py
@@ -190,6 +190,7 @@ async def api_auto_assign(event_id: int):
         return jsonify({'status': 'error'}), 401
 
     ok = await EventService.auto_assign(event_id)
+    current_app.logger.info(f"[auto_assign] event_id={event_id} result={ok}")
     return jsonify({'status': 'ok' if ok else 'error'})
 
 


### PR DESCRIPTION
- 部なしイベント(sessions空)で参加意思あり → 即 accepted に変更
- 希望部全滅時のフォールバックから !sessions.is_empty() 条件を削除（冗長）
- api_auto_assign にログ追加