### PR TITLE
feat(event): 締切自動処理スケジューラー・部制トグルUIを実装

### DIFF
--- a/database_bridge/src/api/handlers/event.rs
+++ b/database_bridge/src/api/handlers/event.rs
@@ -314,6 +314,20 @@ pub async fn mark_participant_notified(
 }
 
 // ============================================================
+// 締切済みイベント一覧（スケジューラー用）
+// ============================================================
+
+/// GET /events/pending-deadline
+pub async fn list_events_past_deadline(
+    State(pool): State<MySqlPool>,
+) -> (StatusCode, Json<Value>) {
+    match event_repo::find_events_past_deadline(&pool).await {
+        Ok(events) => (StatusCode::OK, Json(json!(events))),
+        Err(e) => internal_error(e),
+    }
+}
+
+// ============================================================
 // 自動割り当て
 // ============================================================
 

--- a/database_bridge/src/api/mod.rs
+++ b/database_bridge/src/api/mod.rs
@@ -111,6 +111,7 @@ fn event_routes() -> Router<AppState> {
         .route("/{id}/participants/by-user/{user_id}", get(handlers::event::get_participant_by_user))
         .route("/{id}/auto-assign", post(handlers::event::auto_assign))
         .route("/by-survey/{survey_id}", get(handlers::event::get_event_by_survey))
+        .route("/pending-deadline", get(handlers::event::list_events_past_deadline))
         .route("/participant/{participant_id}", patch(handlers::event::update_participant))
         .route("/participant/{participant_id}/notified", patch(handlers::event::mark_participant_notified))
         .route("/participant/by-token/{token}", get(handlers::event::get_participant_by_token))

--- a/database_bridge/src/db/event_repo.rs
+++ b/database_bridge/src/db/event_repo.rs
@@ -107,6 +107,15 @@ pub async fn update_event_status(pool: &MySqlPool, event_id: i32, status: &str) 
     Ok(())
 }
 
+/// 締切を過ぎた draft/open イベントを返す（スケジューラー用）。
+pub async fn find_events_past_deadline(pool: &MySqlPool) -> BridgeResult<Vec<Event>> {
+    Ok(sqlx::query_as::<_, Event>(&format!(
+        "{EVENT_SELECT} WHERE status IN ('draft','open') AND application_deadline IS NOT NULL AND application_deadline <= NOW()"
+    ))
+    .fetch_all(pool)
+    .await?)
+}
+
 // ============================================================
 // event_sessions
 // ============================================================

--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -5,6 +5,8 @@ import os
 import mysql.connector
 from dotenv import load_dotenv
 
+DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'https://dashboard.awajiempire.net')
+
 # .envファイルを読み込む
 load_dotenv()
 
@@ -131,6 +133,112 @@ async def on_ready():
         mass_mute_cog = bot.get_cog("MassMuteCog")
         if mass_mute_cog:
             asyncio.create_task(mass_mute_cog.execute_mute_logic("Startup/Reconnected"))
+
+    # --- 3. イベント締切スケジューラー起動 ---
+    asyncio.create_task(_event_deadline_scheduler())
+
+
+async def _event_deadline_scheduler():
+    """1分毎に締切済みイベントを処理する: auto_assign → closed → DM一斉送信。"""
+    await bot.wait_until_ready()
+    from services.event_service import EventService
+    from services.notification_service import NotificationService
+    from common.calendar_utils import build_calendar_urls
+
+    try:
+        with open('token.txt', 'r', encoding='utf-8') as f:
+            bot_token = f.read().strip()
+    except FileNotFoundError:
+        bot_token = None
+
+    while not bot.is_closed():
+        try:
+            events = await EventService.get_events_past_deadline()
+            for ev in events:
+                event_id = ev['id']
+                print(f"[deadline_scheduler] Processing event_id={event_id} title={ev['title']}")
+
+                await EventService.auto_assign(event_id)
+                await EventService.update_status(event_id, 'closed')
+
+                result   = await EventService.get_event(event_id)
+                sessions = {s['id']: s for s in result['sessions']} if result else {}
+                participants = await EventService.list_participants(event_id)
+
+                for p in participants:
+                    if p.get('notified_at'):
+                        continue
+
+                    sess = sessions.get(p.get('session_id'))
+                    confirm_url = f"{DASHBOARD_URL}/event/confirm/{p['access_token']}"
+
+                    if p['approval'] == 'accepted':
+                        if sess:
+                            cal = build_calendar_urls(
+                                title=f"{ev['title']} {sess['name']}",
+                                start_str=sess.get('event_date'),
+                                end_str=sess.get('end_date'),
+                                location=sess.get('location'),
+                            )
+                            lines = [
+                                f"【{ev['title']}】参加確定のお知らせ",
+                                '━━━━━━━━━━━━━━━',
+                                f"✅ {sess['name']} 参加確定",
+                            ]
+                            if sess.get('event_date'):
+                                lines.append(f"📅 {sess['event_date']}")
+                            if sess.get('location'):
+                                lines.append(f"📍 {sess['location']}")
+                        else:
+                            cal = build_calendar_urls(
+                                title=ev['title'],
+                                start_str=ev.get('event_date'),
+                                end_str=ev.get('end_date'),
+                                location=ev.get('location'),
+                            )
+                            lines = [
+                                f"【{ev['title']}】参加確定のお知らせ",
+                                '━━━━━━━━━━━━━━━',
+                                '✅ 参加確定',
+                            ]
+                            if ev.get('event_date'):
+                                lines.append(f"📅 {ev['event_date']}")
+                            if ev.get('location'):
+                                lines.append(f"📍 {ev['location']}")
+                        if ev.get('fee'):
+                            lines.append(f"💴 参加費: {ev['fee']}円")
+                        lines += [
+                            '',
+                            '📆 カレンダーに追加:',
+                            f"・Google: {cal['google']}",
+                            f"・Outlook: {cal['outlook']}",
+                            '━━━━━━━━━━━━━━━',
+                            f'詳細確認: {confirm_url}',
+                        ]
+                        message = '\n'.join(lines)
+
+                    elif p['approval'] in ('rejected', 'waitlist'):
+                        message = (
+                            f"【{ev['title']}】参加について\n"
+                            "申し訳ございませんが、今回は参加をお断りさせていただきます。\n"
+                            "またの機会にぜひご参加ください。"
+                        )
+                    else:
+                        continue
+
+                    if bot_token:
+                        ok = await NotificationService.send_dm_raw(
+                            bot_token=bot_token,
+                            user_id=str(p['user_id']),
+                            message=message,
+                        )
+                        if ok:
+                            await EventService.mark_notified(p['id'])
+
+        except Exception as e:
+            print(f"[deadline_scheduler] error: {e}")
+
+        await asyncio.sleep(60)
 
 
 if __name__ == '__main__':

--- a/discord_bot/services/event_service.py
+++ b/discord_bot/services/event_service.py
@@ -179,3 +179,9 @@ class EventService:
         """希望部優先の自動割り当てを実行する。"""
         res = await bridge_client.request("POST", f"/events/{event_id}/auto-assign")
         return res is not None and res.get("status") == "ok"
+
+    @staticmethod
+    async def get_events_past_deadline() -> List[Dict[str, Any]]:
+        """締切を過ぎた draft/open イベントの一覧を返す（スケジューラー用）。"""
+        res = await bridge_client.request("GET", "/events/pending-deadline")
+        return res if isinstance(res, list) else []

--- a/discord_bot/static/js/edit_survey.js
+++ b/discord_bot/static/js/edit_survey.js
@@ -269,12 +269,27 @@ document.getElementById('surveyForm').addEventListener('submit', () => {
 // ============================================================
 
 (function initEventSection() {
-    const checkbox   = document.getElementById('is-event-form');
-    const section    = document.getElementById('event-settings-section');
+    const checkbox    = document.getElementById('is-event-form');
+    const section     = document.getElementById('event-settings-section');
     const sessionList = document.getElementById('event-session-list');
     if (!checkbox || !section) return;
 
+    // 'none' = 部制なし, 'sessions' = n部制
+    let sessionMode = 'none';
     let sessions = [];
+
+    function applySessionMode(mode) {
+        sessionMode = mode;
+        const radioNone     = document.getElementById('session-mode-none');
+        const radioSessions = document.getElementById('session-mode-sessions');
+        if (radioNone)     radioNone.checked     = (mode === 'none');
+        if (radioSessions) radioSessions.checked = (mode === 'sessions');
+        const noFields  = document.getElementById('no-session-fields');
+        const sesFields = document.getElementById('session-fields');
+        if (noFields)  noFields.style.display  = (mode === 'none')     ? '' : 'none';
+        if (sesFields) sesFields.style.display = (mode === 'sessions') ? '' : 'none';
+        syncEventJson();
+    }
 
     // 既存のイベント設定を復元
     const existingJson = checkbox.dataset.eventInfo;
@@ -300,14 +315,24 @@ document.getElementById('surveyForm').addEventListener('submit', () => {
             }));
 
             section.style.display = 'block';
+            applySessionMode(sessions.length > 0 ? 'sessions' : 'none');
             renderSessions();
-            syncEventJson();
         } catch (_) {}
+    } else {
+        applySessionMode('none');
     }
+
+    // 部制ラジオ切り替え
+    document.querySelectorAll('input[name="session-mode"]').forEach(radio => {
+        radio.addEventListener('change', () => {
+            if (radio.value === 'sessions' && sessions.length === 0) addSession();
+            applySessionMode(radio.value);
+            renderSessions();
+        });
+    });
 
     checkbox.addEventListener('change', () => {
         section.style.display = checkbox.checked ? 'block' : 'none';
-        if (checkbox.checked && sessions.length === 0) addSession();
         syncEventJson();
     });
 
@@ -320,6 +345,7 @@ document.getElementById('surveyForm').addEventListener('submit', () => {
     }
 
     function renderSessions() {
+        if (!sessionList) return;
         sessionList.innerHTML = '';
         sessions.forEach((s, i) => {
             const div = document.createElement('div');
@@ -360,12 +386,12 @@ document.getElementById('surveyForm').addEventListener('submit', () => {
         hiddenEl.value = JSON.stringify({
             is_event_form: checkbox.checked,
             fee:                  document.getElementById('event-fee')?.value || null,
-            location:             document.getElementById('event-location')?.value || null,
+            location:             sessionMode === 'none' ? (document.getElementById('event-location')?.value || null) : null,
             notes:                document.getElementById('event-notes')?.value || null,
-            event_date:           document.getElementById('event-date')?.value || null,
-            end_date:             document.getElementById('event-end-date')?.value || null,
+            event_date:           sessionMode === 'none' ? (document.getElementById('event-date')?.value || null) : null,
+            end_date:             sessionMode === 'none' ? (document.getElementById('event-end-date')?.value || null) : null,
             application_deadline: document.getElementById('event-deadline')?.value || null,
-            sessions,
+            sessions: sessionMode === 'sessions' ? sessions : [],
         });
     }
 

--- a/discord_bot/templates/edit.html
+++ b/discord_bot/templates/edit.html
@@ -58,32 +58,45 @@
                             </div>
                         </div>
 
-                        <div style="display:flex; gap:1rem; flex-wrap:wrap;">
-                            <div class="form-group" style="flex:1; min-width:200px;">
-                                <label>開始日時 <span style="font-size:.8rem; color:var(--gray);">（部なしの場合）</span></label>
-                                <input type="datetime-local" id="event-date" class="form-control">
-                            </div>
-                            <div class="form-group" style="flex:1; min-width:200px;">
-                                <label>終了日時 <span style="font-size:.8rem; color:var(--gray);">（省略=開始+2時間）</span></label>
-                                <input type="datetime-local" id="event-end-date" class="form-control">
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <label>集合場所 <span style="font-size:.8rem; color:var(--gray);">（部なしの場合・住所または場所名）</span></label>
-                            <input type="text" id="event-location" class="form-control" placeholder="例: ○○市民会館 大ホール / 東京都千代田区…">
-                        </div>
-
                         <div class="form-group">
                             <label>全体備考</label>
                             <textarea id="event-notes" class="form-control" rows="2" placeholder="参加者全員への共通メモ"></textarea>
                         </div>
 
-                        <div>
-                            <label style="font-weight:bold;"><i class="fas fa-layer-group"></i> 部の設定</label>
-                            <p style="font-size:.82rem; color:var(--gray); margin:.2rem 0 .6rem;">
-                                部を追加しない場合は部制なし（全員共通の日時）になります。
-                            </p>
+                        <div class="form-group">
+                            <label style="font-weight:bold;"><i class="fas fa-layer-group"></i> 部制</label>
+                            <div style="display:flex; gap:1.5rem; margin:.5rem 0;">
+                                <label style="cursor:pointer; display:flex; align-items:center; gap:.4rem;">
+                                    <input type="radio" name="session-mode" id="session-mode-none" value="none">
+                                    部制なし（全員共通）
+                                </label>
+                                <label style="cursor:pointer; display:flex; align-items:center; gap:.4rem;">
+                                    <input type="radio" name="session-mode" id="session-mode-sessions" value="sessions">
+                                    n部制
+                                </label>
+                            </div>
+                        </div>
+
+                        <!-- 部制なし用: 日時・場所 -->
+                        <div id="no-session-fields" style="display:flex; flex-direction:column; gap:1rem;">
+                            <div style="display:flex; gap:1rem; flex-wrap:wrap;">
+                                <div class="form-group" style="flex:1; min-width:200px;">
+                                    <label>開始日時</label>
+                                    <input type="datetime-local" id="event-date" class="form-control">
+                                </div>
+                                <div class="form-group" style="flex:1; min-width:200px;">
+                                    <label>終了日時 <span style="font-size:.8rem; color:var(--gray);">（省略=開始+2時間）</span></label>
+                                    <input type="datetime-local" id="event-end-date" class="form-control">
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label>集合場所 <span style="font-size:.8rem; color:var(--gray);">（住所または場所名）</span></label>
+                                <input type="text" id="event-location" class="form-control" placeholder="例: ○○市民会館 大ホール / 東京都千代田区…">
+                            </div>
+                        </div>
+
+                        <!-- n部制用: 部リスト -->
+                        <div id="session-fields" style="display:none;">
                             <div id="event-session-list"></div>
                             <button type="button" id="btn-add-session" class="btn btn-outline btn-sm">
                                 <i class="fas fa-plus"></i> 部を追加


### PR DESCRIPTION
- Bridge: GET /events/pending-deadline エンドポイント追加
- EventService: get_events_past_deadline() 追加
- bot.py: 1分毎の締切スケジューラー（auto_assign→closed→DM一斉送信） waitlistは自動で不参加通知DMを送信
- edit.html + edit_survey.js: 部制なし/n部制ラジオトグル追加 部制なしでも締切・日時・場所を設定可能