### PR TITLE
fix(event): 自動割り当てのDB未移行耐性強化・DOM直接更新・イベントCSV対応

### DIFF
--- a/database_bridge/src/api/handlers/event.rs
+++ b/database_bridge/src/api/handlers/event.rs
@@ -341,12 +341,19 @@ pub async fn auto_assign(
     State(pool): State<MySqlPool>,
     Path(event_id): Path<i32>,
 ) -> (StatusCode, Json<Value>) {
-    let event_capacity = match event_repo::find_event_by_id(&pool, event_id).await {
-        Ok(e) => e.capacity,
-        Err(e) => return internal_error(e),
-    };
+    // capacity 取得失敗時はフォールバック（None = 無制限）として処理継続
+    let event_capacity = event_repo::find_event_by_id(&pool, event_id)
+        .await
+        .ok()
+        .and_then(|e| e.capacity);
     match event_repo::auto_assign(&pool, event_id, event_capacity).await {
-        Ok(_) => (StatusCode::OK, Json(json!({"status": "ok"}))),
+        Ok(_) => {
+            // 割り当て後の参加者一覧を返すことでフロント側がリロードなしでDOMを更新できる
+            match event_repo::find_participants_by_event(&pool, event_id).await {
+                Ok(participants) => (StatusCode::OK, Json(json!({"status": "ok", "participants": participants}))),
+                Err(_) => (StatusCode::OK, Json(json!({"status": "ok", "participants": []}))),
+            }
+        },
         Err(e) => internal_error(e),
     }
 }

--- a/discord_bot/routes/survey.py
+++ b/discord_bot/routes/survey.py
@@ -420,6 +420,7 @@ async def download_csv(survey_id):
             return "Forbidden", 403
 
         responses = await SurveyService.get_responses(None, survey_id)
+        event_info = await EventService.get_event_by_survey(survey_id)
     except BridgeUnavailableError:
         return await render_template('maintenance.html'), 503
     except Exception:
@@ -429,14 +430,46 @@ async def download_csv(survey_id):
     si = io.StringIO()
     writer = csv.writer(si)
 
+    # イベントフォームの場合: 参加者情報を response_id で引けるよう map 化
+    participant_map = {}
+    session_map = {}
+    if event_info:
+        event_id = event_info['event']['id']
+        participants = await EventService.list_participants(event_id)
+        participant_map = {str(p['response_id']): p for p in participants if p.get('response_id')}
+        session_map = {s['id']: s['name'] for s in event_info.get('sessions', [])}
+
+    # ヘッダー行
     header = ['回答日時', '回答者']
+    if event_info:
+        header += ['参加意思', '状態', '割り当て部', '希望部']
     for i, q in enumerate(questions):
         q_text = q.get('text', f'Q{i+1}')
         header.append(f"Q{i+1}: {q_text}")
     writer.writerow(header)
 
+    APPROVAL_LABELS = {'pending': '確認中', 'accepted': '承認', 'rejected': '否認', 'waitlist': '補欠'}
+
     for r in responses:
         row = [str(r['submitted_at']), r['user_name']]
+
+        if event_info:
+            p = participant_map.get(str(r['id']))
+            if p:
+                # 参加意思: preferred_session_ids が None なら不参加
+                attending = '不参加' if p.get('preferred_session_ids') is None else '参加'
+                approval = APPROVAL_LABELS.get(p.get('approval', ''), p.get('approval', ''))
+                assigned = session_map.get(p.get('session_id')) if p.get('session_id') else ''
+                # 希望部: preferred_session_ids JSON から部名リストに変換
+                try:
+                    pref_ids = json.loads(p['preferred_session_ids']) if isinstance(p.get('preferred_session_ids'), str) else []
+                    preferred = ', '.join(session_map.get(sid, str(sid)) for sid in pref_ids) if pref_ids else ''
+                except Exception:
+                    preferred = ''
+                row += [attending, approval, assigned, preferred]
+            else:
+                row += ['', '', '', '']
+
         try:
             ans_json = r['answers']
             if isinstance(ans_json, str):

--- a/discord_bot/static/js/event_admin.js
+++ b/discord_bot/static/js/event_admin.js
@@ -48,16 +48,40 @@
     // 自動割り当て
     // ============================================================
 
+    const APPROVAL_LABELS = { pending: '確認中', accepted: '承認', rejected: '否認', waitlist: '補欠' };
+
     window.autoAssign = async function () {
         if (!confirm('自動割り当てを実行しますか？\n既に「承認」「否認」済みの方はスキップされます。')) return;
         const res = await fetch(`/event/api/${EVENT_ID}/auto-assign`, { method: 'POST' });
+        if (!res.ok) { alert('割り当てに失敗しました'); return; }
         const d = await res.json();
-        if (d.status === 'ok') {
-            alert('割り当て完了。ページを更新します。');
-            location.reload();
-        } else {
-            alert('割り当てに失敗しました');
-        }
+        if (d.status !== 'ok') { alert('割り当てに失敗しました'); return; }
+
+        // レスポンスに含まれる最新の参加者データでDOMを直接更新
+        let updated = 0;
+        (d.participants || []).forEach(p => {
+            const row = document.getElementById(`row-${p.id}`);
+            if (!row) return;
+
+            const approvalSel = row.querySelector('.select-approval');
+            if (approvalSel && approvalSel.value !== p.approval) {
+                approvalSel.value = p.approval;
+                updated++;
+            }
+
+            const sessionSel = row.querySelector('.select-session');
+            if (sessionSel) {
+                const newVal = p.session_id != null ? String(p.session_id) : '';
+                if (sessionSel.value !== newVal) {
+                    sessionSel.value = newVal;
+                    updated++;
+                }
+            }
+        });
+
+        alert(`割り当て完了（${updated}件更新）。`);
+        // 部ごとの残席カウントはページリロードで最新化
+        location.reload();
     };
 
     // ============================================================

--- a/discord_bot/templates/event_admin.html
+++ b/discord_bot/templates/event_admin.html
@@ -69,6 +69,9 @@
             <button class="btn btn-success" onclick="notifyAll()" id="btn-notify">
                 <i class="fas fa-paper-plane"></i> 全員に通知送信
             </button>
+            <a href="{{ url_for('survey.download_csv', survey_id=event['survey_id']) }}" class="btn btn-outline">
+                <i class="fas fa-download"></i> CSV ダウンロード
+            </a>
         </div>
     </div>
 


### PR DESCRIPTION
- auto_assign ハンドラー: find_event_by_id 失敗時に capacity=None でフォールバック （migration 011 未適用でも動作継続）
- auto_assign レスポンスに participants を含め、JS 側でDOMを直接更新 （ページリロードに依存した状態更新を廃止し割り当て部の反映を確実に）
- download_csv: イベントフォームの場合に参加意思・状態・割り当て部・希望部列を追加
- event_admin.html に CSV ダウンロードボタンを追加