### PR TITLE
fix(event): カレンダーDM通知のタイムゾーンとMarkdown不具合を修正

### DIFF
--- a/discord_bot/common/calendar_utils.py
+++ b/discord_bot/common/calendar_utils.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 
 
 _DT_FMT_IN  = "%Y-%m-%d %H:%M:%S"  # DB から来る形式
-_DT_FMT_GCL = "%Y%m%dT%H%M%SZ"     # Google Calendar 形式
+_DT_FMT_GCL = "%Y%m%dT%H%M%S"      # Google Calendar 形式（ローカル時刻、Z なし）
 
 
 def _parse_dt(dt_str: str | None) -> datetime | None:

--- a/discord_bot/routes/event.py
+++ b/discord_bot/routes/event.py
@@ -252,8 +252,8 @@ async def api_notify(event_id: int):
             lines += [
                 '',
                 '📆 カレンダーに追加:',
-                f"・Google: {cal['google']}",
-                f"・Outlook: {cal['outlook']}",
+                f"・Google: <{cal['google']}>",
+                f"・Outlook: <{cal['outlook']}>",
                 '━━━━━━━━━━━━━━━',
                 f'詳細確認: {confirm_url}',
             ]


### PR DESCRIPTION
- Google Calendar URL の日時形式から Z サフィックスを除去（JSTローカル時刻をUTCと誤認していた）
- カレンダーURLを <URL> 形式でラップし、Discord がURL内の日本語文字をMarkdownとして誤解析するのを防止