### PR TITLE
refactor(bot): Discord トークン管理を token.txt から DISCORD_TOKEN 環境変数へ移行

### DIFF
--- a/discord_bot/.env.example
+++ b/discord_bot/.env.example
@@ -8,6 +8,8 @@
 # ----------------------------------------
 # Discord Bot
 # ----------------------------------------
+# Bot トークン (Discord Developer Portal > Bot > Token)
+DISCORD_TOKEN=your_bot_token_here
 # 管理者ユーザー ID (DM 送信先)
 ADMIN_USER_ID=000000000000000000
 # Bot を登録するギルド (サーバー) の ID

--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -2,14 +2,14 @@ import discord
 from discord.ext import commands
 import asyncio
 import os
+import sys
 import mysql.connector
 from dotenv import load_dotenv
 
-DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'https://dashboard.awajiempire.net')
-
-# .envファイルを読み込む
+# .envファイルを読み込む（他の os.getenv より先に呼ぶ）
 load_dotenv()
 
+DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'https://dashboard.awajiempire.net')
 ADMIN_USER_ID = os.getenv('ADMIN_USER_ID', '')
 DISCORD_GUILD_ID = os.getenv('DISCORD_GUILD_ID', '')
 
@@ -75,18 +75,13 @@ class MyBot(commands.Bot):
 # Botインスタンスの作成
 bot = MyBot()
 
-def get_token_from_file(filename="token.txt"):
-    """token.txtファイルからトークンを読み込む"""
-    try:
-        with open(filename, 'r') as f:
-            token = f.read().strip()
-            return token
-    except FileNotFoundError:
-        print(f"Error: Token file '{filename}' not found.")
+def get_token() -> str | None:
+    """環境変数 DISCORD_TOKEN からトークンを取得する"""
+    token = os.getenv('DISCORD_TOKEN', '').strip()
+    if not token:
+        print("Error: DISCORD_TOKEN が設定されていません。.env を確認してください。", file=sys.stderr)
         return None
-    except Exception as e:
-        print(f"Error reading token file: {e}")
-        return None
+    return token
 
 @bot.event
 async def on_ready():
@@ -145,11 +140,7 @@ async def _event_deadline_scheduler():
     from services.notification_service import NotificationService
     from common.calendar_utils import build_calendar_urls
 
-    try:
-        with open('token.txt', 'r', encoding='utf-8') as f:
-            bot_token = f.read().strip()
-    except FileNotFoundError:
-        bot_token = None
+    bot_token = os.getenv('DISCORD_TOKEN', '').strip() or None
 
     while not bot.is_closed():
         try:
@@ -242,8 +233,8 @@ async def _event_deadline_scheduler():
 
 
 if __name__ == '__main__':
-    bot_token = get_token_from_file()
-    
+    bot_token = get_token()
+
     if bot_token:
         try:
             bot.run(bot_token, reconnect=True)

--- a/discord_bot/main.py
+++ b/discord_bot/main.py
@@ -1,5 +1,29 @@
-def main():
-    print("Hello from discord-bot!")
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent / ".env")
+
+
+def get_token() -> str:
+    token = os.getenv("DISCORD_TOKEN", "").strip()
+    if not token:
+        print(
+            "[ERROR] DISCORD_TOKEN が設定されていません。\n"
+            "  .env に DISCORD_TOKEN=<your_token> を追加するか、\n"
+            "  scripts/migrate_token.py で token.txt から移行してください。",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return token
+
+
+def main() -> None:
+    token = get_token()
+    # TODO: discord.py の Bot 初期化・起動処理をここに実装する
+    print(f"Bot トークン読み込み成功 (末尾4文字: ...{token[-4:]})")
 
 
 if __name__ == "__main__":

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,6 +203,30 @@ database_bridge/
 | **Discord OAuth2** | Web ダッシュボードの認証（ギルドメンバー限定） |
 | **Discord Bot Token** | DM 送信・ロール同期・音声チャンネル管理 |
 
+### 6.3 シークレット管理
+
+全シークレットは **サーバー上の `/Awaji-Empire-Agent/discord_bot/.env`** で一元管理する。このファイルはリポジトリに含まれず（`.gitignore` 対象）、手動で配置・更新する。
+
+| キー | 用途 |
+|---|---|
+| `DISCORD_TOKEN` | Bot トークン（`bot.py` 起動・DM 送信） |
+| `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | OAuth2 認証（Web ダッシュボード） |
+| `DB_HOST` / `DB_NAME` / `DB_USER` / `DB_PASS` | MariaDB 接続情報 |
+| `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` | Cloudflare Zero Trust |
+| `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` | Cloudflare サービストークン |
+
+各 systemd サービスは `EnvironmentFile=/Awaji-Empire-Agent/discord_bot/.env` により `.env` を自動的に読み込む。`bot.py` は起動時に `load_dotenv()` でも同ファイルを読み込む（systemd 経由でない手動起動への対応）。
+
+### 6.4 systemd サービス構成
+
+サービスファイルは `infra/` で一元管理し、CI/CD が自動的に `/etc/systemd/system/` へ適用する。
+
+| サービスファイル | 役割 |
+|---|---|
+| `infra/discord_bot.service` | Bot プロセス（`bot.py`） |
+| `infra/discord_webapp.service` | Web ダッシュボード（`webapp.py`） |
+| `infra/database_bridge.service` | Rust Bridge（`database_bridge`） |
+
 ---
 
 ## 7. デプロイ手順
@@ -221,22 +245,34 @@ database_bridge/
 
 ### 7.2 デプロイ手順
 
+`master` ブランチへの push で GitHub Actions が自動実行する。手動デプロイが必要な場合は以下を参照。
+
 ```bash
 # 1. コード取得
 git pull origin master
 
-# 2. database_bridge をビルド・再起動（systemd / pm2 等）
+# 2. systemd サービスファイルを適用（infra/*.service → /etc/systemd/system/）
+sudo /Awaji-Empire-Agent/scripts/setup-systemd.sh
+
+# 3. database_bridge をビルド・再起動
 cd database_bridge
 cargo build --release
 # → 起動時に未適用マイグレーションが自動実行される
 
-# 3. 起動ログで確認
-# "Applied migration 009_event_form" 〜 "Applied migration 011_event_capacity" が出ればOK
-# エラー時はプロセスが停止する（ロールバックなし）
+# 4. 各サービスを再起動
+sudo systemctl restart discord_bot.service
+sudo systemctl restart discord_webapp.service
+```
 
-# 4. discord_bot を再起動
-cd discord_bot
-# systemd / pm2 等で再起動
+**CI/CD（GitHub Actions）での自動適用フロー：**
+
+```
+push to master
+  └─ Rust bridge ビルド
+  └─ rsync でサーバーへ同期
+  └─ uv sync（Python 依存解決）
+  └─ setup-systemd.sh（infra/*.service を全件インストール + daemon-reload）
+  └─ systemctl restart discord_bot / discord_webapp
 ```
 
 ### 7.3 新規マイグレーションファイルの追加ルール

--- a/docs/adr/023-discord-token-dotenv-migration.md
+++ b/docs/adr/023-discord-token-dotenv-migration.md
@@ -1,0 +1,111 @@
+# ADR-023: Discord Bot トークン管理を token.txt から .env へ移行
+
+- **ステータス**: 採用
+- **作成日**: 2026-05-28
+- **作成者**: Wanyaldee
+
+---
+
+## コンテキスト
+
+`bot.py` は起動時および締切スケジューラー内の DM 送信処理で、Discord Bot トークンを `token.txt` ファイルから直接読み込んでいた。
+
+```python
+# 旧実装（2箇所存在）
+with open('token.txt', 'r') as f:
+    token = f.read().strip()
+```
+
+この設計には以下の問題があった。
+
+1. **平文ファイルの管理が属人的**: `token.txt` はどこに置くか、誰が管理するかが暗黙知になっていた。
+2. **他のシークレットと管理方式が分断**: DB 認証情報・Cloudflare トークン等はすでに `.env` で管理しているのに、Discord トークンだけ別方式だった。
+3. **systemd との連携漏れ**: `discord_bot.service` に `EnvironmentFile=` が設定されておらず、`.env` の値がプロセスに渡っていなかった。
+4. **`load_dotenv()` 呼び出し順バグ**: `load_dotenv()` より前に `os.getenv('DASHBOARD_URL')` が呼ばれており、`.env` が読まれる前にデフォルト値が確定していた。
+
+また、`setup-systemd.sh` が `database_bridge.service` のみを対象としており、`discord_bot.service` と `discord_webapp.service` はリポジトリ外で手動管理されていた。
+
+---
+
+## 決定内容
+
+### 1. bot.py: `DISCORD_TOKEN` 環境変数から取得
+
+`python-dotenv` はすでに `requirements.txt` に含まれているため、追加依存なし。
+
+```python
+# load_dotenv() を全 os.getenv() より先頭に移動
+load_dotenv()
+
+# トークン取得を一本化
+def get_token() -> str | None:
+    token = os.getenv('DISCORD_TOKEN', '').strip()
+    if not token:
+        print("Error: DISCORD_TOKEN が設定されていません。", file=sys.stderr)
+        return None
+    return token
+```
+
+締切スケジューラー内の `open('token.txt')` も `os.getenv('DISCORD_TOKEN')` に統一した。
+
+### 2. discord_bot.service に `EnvironmentFile=` を追加
+
+```ini
+EnvironmentFile=/Awaji-Empire-Agent/discord_bot/.env
+```
+
+これにより、systemd が Bot プロセスを起動する際に `.env` の全変数が自動的に環境変数として渡される。
+
+### 3. 全サービスファイルを `infra/` で一元管理
+
+| ファイル | 用途 |
+|---|---|
+| `infra/database_bridge.service` | 既存（変更なし） |
+| `infra/discord_bot.service` | 新規追加（`EnvironmentFile=` 含む） |
+| `infra/discord_webapp.service` | 新規追加（既存設定をリポジトリに収録） |
+
+### 4. `setup-systemd.sh` を汎用化
+
+`infra/*.service` を全てループしてインストールする形に変更。以後、サービスファイルを追加するだけで CI/CD が自動適用する。
+
+```bash
+for SOURCE_PATH in "${INFRA_DIR}"/*.service; do
+    cp "${SOURCE_PATH}" "${SYSTEMD_DIR}/$(basename "${SOURCE_PATH}")"
+    systemctl enable "$(basename "${SOURCE_PATH}")"
+done
+systemctl daemon-reload
+```
+
+### 5. `.env` への `DISCORD_TOKEN` キー追加
+
+`.env` および `.env.example` に `DISCORD_TOKEN=` を明示。実値はサーバー上の `.env` に手動で設定済み。
+
+---
+
+## 検討した代替案
+
+### token.txt を継続し .env に追記しない
+
+- **却下理由**: 同じプロセスが `DB_PASS` を `.env` から読み、`DISCORD_TOKEN` だけ別ファイルから読む二重管理は保守コストが高い。
+
+### dotenvx を導入して暗号化管理
+
+- **却下理由**: 現時点では物理サーバー上の `.env` はファイルシステム権限（root 所有 / devuser 読み取り不可）で保護されており、暗号化の優先度は低い。将来的なオプションとして保留。
+
+### GitHub Actions Secrets から直接 systemd に注入
+
+- **却下理由**: self-hosted runner 環境では `.env` ファイルを直接サーバーに置く方が設定が単純。Secrets 経由にするとデプロイ時の上書きロジックが複雑になる。
+
+---
+
+## 影響範囲
+
+| 対象 | 変更内容 |
+|---|---|
+| `discord_bot/bot.py` | `load_dotenv()` 順序修正・`get_token_from_file()` 廃止・`DISCORD_TOKEN` 環境変数で統一 |
+| `discord_bot/.env` | `DISCORD_TOKEN` キー追加 |
+| `discord_bot/.env.example` | `DISCORD_TOKEN` キー追加（説明コメント付き） |
+| `infra/discord_bot.service` | 新規追加（`EnvironmentFile=` 含む） |
+| `infra/discord_webapp.service` | 新規追加（既存設定をリポジトリに収録） |
+| `scripts/setup-systemd.sh` | `infra/*.service` 全件ループに汎用化 |
+| `infra/sudoers_deploy` | `discord_bot.service` の enable/restart/status 権限を追加 |

--- a/infra/discord_bot.service
+++ b/infra/discord_bot.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Discord Bot Service
+After=network.target mysql.service
+
+[Service]
+Environment=PYTHONPATH=/Awaji-Empire-Agent/discord_bot
+User=devuser
+Group=root
+WorkingDirectory=/Awaji-Empire-Agent/discord_bot
+EnvironmentFile=/Awaji-Empire-Agent/discord_bot/.env
+ExecStart=/Awaji-Empire-Agent/discord_bot/.venv/bin/python3 bot.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/discord_webapp.service
+++ b/infra/discord_webapp.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Discord Bot Web Dashboard
+After=network.target mysql.service
+
+[Service]
+User=devuser
+Group=root
+WorkingDirectory=/Awaji-Empire-Agent/discord_bot
+Environment=DISCORD_REDIRECT_URI=https://dashboard.awajiempire.net/callback
+EnvironmentFile=/Awaji-Empire-Agent/discord_bot/.env
+ExecStart=/Awaji-Empire-Agent/discord_bot/.venv/bin/python3 webapp.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/sudoers_deploy
+++ b/infra/sudoers_deploy
@@ -12,6 +12,10 @@
 <USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable database_bridge.service
 <USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart database_bridge.service
 <USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl status database_bridge.service
+<USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable discord_bot.service
+<USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart discord_bot.service
+<USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl status discord_bot.service
+<USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl enable discord_webapp.service
 <USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart discord_webapp.service
 <USER> ALL=(ALL) NOPASSWD: /usr/bin/systemctl status discord_webapp.service
 

--- a/scripts/setup-systemd.sh
+++ b/scripts/setup-systemd.sh
@@ -1,40 +1,33 @@
 #!/bin/bash
 
 # setup-systemd.sh
-# Why: Automate the registration and start of the database_bridge service.
+# Why: infra/ 配下の全 .service ファイルを /etc/systemd/system/ へインストールし enable する。
+#      CI/CD から呼ばれることを前提とし、サービスの追加・変更はこのスクリプト1本で完結させる。
 
-SERVICE_NAME="database_bridge.service"
-SOURCE_PATH="/Awaji-Empire-Agent/infra/$SERVICE_NAME"
-TARGET_PATH="/etc/systemd/system/$SERVICE_NAME"
+INFRA_DIR="/Awaji-Empire-Agent/infra"
+SYSTEMD_DIR="/etc/systemd/system"
 
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root (sudo)"
-   exit 1
-fi
-
-echo "--- Setting up $SERVICE_NAME ---"
-
-if [ ! -f "$SOURCE_PATH" ]; then
-    echo "Error: Source service file not found at $SOURCE_PATH"
+    echo "This script must be run as root (sudo)"
     exit 1
 fi
 
-# Copy the service file
-echo "Copying $SERVICE_NAME to $TARGET_PATH..."
-cp "$SOURCE_PATH" "$TARGET_PATH"
+echo "--- Setting up systemd services from ${INFRA_DIR} ---"
 
-# Reload systemd
+for SOURCE_PATH in "${INFRA_DIR}"/*.service; do
+    [ -f "${SOURCE_PATH}" ] || continue
+
+    SERVICE_NAME="$(basename "${SOURCE_PATH}")"
+    TARGET_PATH="${SYSTEMD_DIR}/${SERVICE_NAME}"
+
+    echo "Copying ${SERVICE_NAME} → ${TARGET_PATH}"
+    cp "${SOURCE_PATH}" "${TARGET_PATH}"
+
+    echo "Enabling ${SERVICE_NAME}..."
+    systemctl enable "${SERVICE_NAME}"
+done
+
 echo "Reloading systemd daemon..."
 systemctl daemon-reload
 
-# Enable and start
-echo "Enabling $SERVICE_NAME..."
-systemctl enable "$SERVICE_NAME"
-
-echo "Restarting $SERVICE_NAME..."
-systemctl restart "$SERVICE_NAME"
-
-echo "Checking status of $SERVICE_NAME..."
-systemctl status "$SERVICE_NAME" --no-pager
-
-echo "✅ Setup completed successfully."
+echo "✅ All services installed successfully."


### PR DESCRIPTION
- bot.py: load_dotenv() を先頭に移動・get_token_from_file() 廃止・スケジューラー内の token.txt 直読みを削除
- infra/discord_bot.service: EnvironmentFile= を追加しリポジトリで管理開始
- infra/discord_webapp.service: 既存設定をリポジトリに収録
- scripts/setup-systemd.sh: database_bridge 固定 → infra/*.service 全件ループに汎用化
- infra/sudoers_deploy: discord_bot.service の enable/restart/status 権限を追加
- docs: ADR-023 追加・ARCHITECTURE.md にシークレット管理とsystemd構成を追記