### PR TITLE
fix(webapp): DM トークンを .env(DISCORD_TOKEN) 優先にし共同編集DM不達を修正

### DIFF
--- a/discord_bot/routes/event.py
+++ b/discord_bot/routes/event.py
@@ -16,11 +16,14 @@ event_bp = Blueprint('event', __name__, url_prefix='/event')
 
 DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'https://dashboard.awajiempire.net')
 
-try:
-    with open('token.txt', 'r', encoding='utf-8') as f:
-        DISCORD_BOT_TOKEN = f.read().strip()
-except FileNotFoundError:
-    DISCORD_BOT_TOKEN = None
+# ADR-023 以降、トークンは .env の DISCORD_TOKEN で管理する（token.txt はフォールバック）。
+DISCORD_BOT_TOKEN = os.getenv('DISCORD_TOKEN', '').strip() or None
+if not DISCORD_BOT_TOKEN:
+    try:
+        with open('token.txt', 'r', encoding='utf-8') as f:
+            DISCORD_BOT_TOKEN = f.read().strip()
+    except FileNotFoundError:
+        DISCORD_BOT_TOKEN = None
 
 
 def _current_user():

--- a/discord_bot/routes/survey.py
+++ b/discord_bot/routes/survey.py
@@ -35,11 +35,15 @@ survey_bp = Blueprint('survey', __name__)
 # Bot Token の読み込み
 # Why: DM送信時にBot Tokenが必要。routes 層では読み込みのみ行い、
 #      実際の送信処理は NotificationService に委譲する。
-try:
-    with open('token.txt', 'r', encoding='utf-8') as f:
-        DISCORD_BOT_TOKEN = f.read().strip()
-except FileNotFoundError:
-    DISCORD_BOT_TOKEN = None
+# ADR-023 以降、トークンは .env の DISCORD_TOKEN で管理する。
+#      旧 token.txt はフォールバックとしてのみ残す。
+DISCORD_BOT_TOKEN = os.getenv('DISCORD_TOKEN', '').strip() or None
+if not DISCORD_BOT_TOKEN:
+    try:
+        with open('token.txt', 'r', encoding='utf-8') as f:
+            DISCORD_BOT_TOKEN = f.read().strip()
+    except FileNotFoundError:
+        DISCORD_BOT_TOKEN = None
 
 DASHBOARD_URL = os.getenv('DASHBOARD_URL', 'https://dashboard.awajiempire.net')
 

--- a/discord_bot/templates/form.html
+++ b/discord_bot/templates/form.html
@@ -21,7 +21,7 @@
                 <div style="margin-top:1rem;">
                     <button type="button" id="shareBtn" onclick="shareForm()"
                         style="background:#5865F2; color:#fff; border:none; border-radius:6px; padding:.55rem 1.2rem; font-size:.9rem; cursor:pointer;">
-                        <i class="fas fa-share-alt"></i> 回答リンクを共有
+                        <i class="fas fa-share-alt"></i> 回答リンクをコピー
                     </button>
                     <span id="shareMsg" style="display:none; color:var(--success); font-size:.85rem; margin-left:.6rem;">
                         <i class="fas fa-check"></i> リンクをコピーしました
@@ -256,13 +256,11 @@
 
     <script src="{{ url_for('static', filename='js/form.js') }}"></script>
     <script>
-        // 回答リンク共有: Web Share API → クリップボード → prompt の順でフォールバック
+        // 回答リンク共有: クリップボードへ自動コピーを優先（他画面の共有ボタンと挙動を統一）。
+        // クリップボード非対応環境のみ prompt にフォールバック。
         function shareForm() {
             const url = window.location.href;
-            const title = {{ survey['title'] | tojson }};
-            if (navigator.share) {
-                navigator.share({ title: title, url: url }).catch(function () {});
-            } else if (navigator.clipboard && navigator.clipboard.writeText) {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
                 navigator.clipboard.writeText(url).then(showShareMsg).catch(function () {
                     window.prompt('以下のリンクをコピーしてください', url);
                 });

--- a/discord_bot/webapp.py
+++ b/discord_bot/webapp.py
@@ -6,6 +6,10 @@ from quart import Quart, render_template, request, redirect, url_for, session, c
 from quart_cors import cors
 from dotenv import load_dotenv
 
+# routes/* のモジュール読込時に DISCORD_TOKEN 等を参照するため、
+# ブループリント import より前に .env を読み込む（ADR-023）。
+load_dotenv()
+
 from routes.survey import survey_bp
 from routes.lobby import lobby_bp
 from routes.tournament import tournament_bp
@@ -17,8 +21,6 @@ from services.lounge_service import LoungeService
 from services.bridge_client import BridgeUnavailableError
 from services.survey_service import SurveyService
 from services.log_service import LogService
-
-load_dotenv()
 
 ADMIN_USER_ID = os.getenv("ADMIN_USER_ID", "")
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -198,3 +198,30 @@ CI/CD は `cargo build --release` で新バイナリを作り rsync するが、
 > **Rust(`database_bridge`)に変更を入れたら、deploy で必ず `database_bridge.service` を
 > restart すること。依存サービス（bot/webapp）より先に bridge を再起動する。**
 > sudoers では既に restart が許可済み（`infra/sudoers_deploy`）。ビルド成功＝反映ではない。
+
+---
+
+## LESSON-008: webapp 側 DM が token.txt 依存で送信されない（ADR-023 移行漏れ）
+
+- **発見日**: 2026-06-14
+- **症状**: 共同編集者の割り当て時など、webapp からの Discord DM が届かない
+- **修正**: `routes/survey.py` / `routes/event.py` のトークン取得を
+  `os.getenv('DISCORD_TOKEN')` 優先・`token.txt` フォールバックに変更し、
+  `webapp.py` の `load_dotenv()` をブループリント import より前へ移動
+
+### 何が起きたか
+
+ADR-023 で Bot のトークンを `token.txt` から `.env` の `DISCORD_TOKEN` へ移行したが、
+**webapp 側の `routes/*.py` は `token.txt` 読み込みのまま**だった。サーバーに token.txt が
+存在しないため `DISCORD_BOT_TOKEN = None` となり、`NotificationService.send_dm_raw` が
+「Bot token missing」で送信をスキップしていた（例外は出ず静かに失敗）。
+
+加えて `webapp.py` では `from routes.survey import ...` が `load_dotenv()` より前にあり、
+モジュール読込時の `os.getenv` が .env 反映前に評価される順序問題もあった
+（systemd の EnvironmentFile があるため本番では顕在化しにくいが、ローカルで壊れる）。
+
+### ルール
+
+> **トークン等のシークレットは `.env`(DISCORD_TOKEN) を唯一の正とし、Bot だけでなく
+> webapp の routes/services も同じ取得経路にすること。`token.txt` 依存を残さない。**
+> モジュール読込時に env を参照するなら `load_dotenv()` を import より前に置く。


### PR DESCRIPTION
- routes/survey.py・routes/event.py のトークン取得を DISCORD_TOKEN 優先＋ token.txt フォールバックに変更（ADR-023 の移行漏れ。token.txt 不在で DISCORD_BOT_TOKEN=None となり DM が静かに失敗していた）
- webapp.py の load_dotenv() をブループリント import より前へ移動し、 モジュール読込時の env 参照を確実化
- 回答リンク共有ボタンをクリップボード自動コピー優先に統一（form.html）
- LESSON-008 として記録